### PR TITLE
Code refactoring for application properties

### DIFF
--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/Route.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/Route.java
@@ -8,7 +8,7 @@ import org.apache.camel.builder.RouteBuilder;
 import ca.bc.gov.hlth.hnsecure.authorization.ValidateAccessToken;
 import ca.bc.gov.hlth.hnsecure.exception.CustomHNSException;
 import ca.bc.gov.hlth.hnsecure.message.ValidationFailedException;
-import ca.bc.gov.hlth.hnsecure.messagevalidation.AccessValidator;
+import ca.bc.gov.hlth.hnsecure.messagevalidation.ExceptionHandler;
 import ca.bc.gov.hlth.hnsecure.messagevalidation.V2PayloadValidator;
 import ca.bc.gov.hlth.hnsecure.parsing.FhirPayloadExtractor;
 import ca.bc.gov.hlth.hnsecure.parsing.PopulateReqHeader;
@@ -16,52 +16,20 @@ import ca.bc.gov.hlth.hnsecure.properties.ApplicationProperties;
 import ca.bc.gov.hlth.hnsecure.temporary.samplemessages.SampleMessages;
 
 public class Route extends RouteBuilder {
-	/*
-
-    @PropertyInject(value = "audience")
-    private String audiences;
-    @PropertyInject(value = "authorized-parties")
-    private String authorizedParties;
-    @PropertyInject(value = "scopes")
-    private String scopes;
-    @PropertyInject(value = "issuer")
-    private String issuer;
-    @PropertyInject(value = "valid-v2-message-types")
-    private String validV2MessageTypes;
-    @PropertyInject(value = "certs-endpoint")
-    private String certsEndpoint;
-    @PropertyInject(value = "valid-receiving-facility")
-    private String validReceivingFacility;
-    @PropertyInject(value = "processing-domain")
-    private String processingDomain;
-    @PropertyInject(value = "version")
-    private String version;
-    */
-
-
-    // PropertyInject doesn't seem to work in the unit tests, allows creation of the route setting this value
-	/*
-    public Route(String validV2MessageTypes, String validReceivingFacility, String processingDomain, String version) {
-        this.validV2MessageTypes = validV2MessageTypes;
-        this.validReceivingFacility = validReceivingFacility;
-        this.processingDomain = processingDomain;
-        this.version = version;
-    }
-    */
 
     @Override
     public void configure() {
     	injectProperties();
         //AuthorizationProperties authProperties = new AuthorizationProperties(audiences, authorizedParties, scopes, validV2MessageTypes, issuer, validReceivingFacility,processingDomain,version);
-        //TODO just pass auth properties into the method
-    	// TODO completed by using injecting properties    
+        // TODO just pass auth properties into the method
+    	// completed by using injecting properties    
         V2PayloadValidator v2PayloadValidator = new V2PayloadValidator();
         ValidateAccessToken validateAccessToken = new ValidateAccessToken();
         
 
         // Handling custom exception  
         onException(CustomHNSException.class)
-        	.process(new AccessValidator())
+        	.process(new ExceptionHandler())
         	.handled(true);
         
         onException(ValidationFailedException.class)

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/Route.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/Route.java
@@ -1,22 +1,22 @@
 package ca.bc.gov.hlth.hnsecure;
 
-import ca.bc.gov.hlth.hnsecure.authorization.AuthorizationProperties;
-import ca.bc.gov.hlth.hnsecure.messagevalidation.AccessValidator;
-import ca.bc.gov.hlth.hnsecure.messagevalidation.V2PayloadValidator;
+
+import java.util.Properties;
+
+import org.apache.camel.builder.RouteBuilder;
+
 import ca.bc.gov.hlth.hnsecure.authorization.ValidateAccessToken;
 import ca.bc.gov.hlth.hnsecure.exception.CustomHNSException;
 import ca.bc.gov.hlth.hnsecure.message.ValidationFailedException;
+import ca.bc.gov.hlth.hnsecure.messagevalidation.AccessValidator;
+import ca.bc.gov.hlth.hnsecure.messagevalidation.V2PayloadValidator;
 import ca.bc.gov.hlth.hnsecure.parsing.FhirPayloadExtractor;
 import ca.bc.gov.hlth.hnsecure.parsing.PopulateReqHeader;
 import ca.bc.gov.hlth.hnsecure.properties.ApplicationProperties;
 import ca.bc.gov.hlth.hnsecure.temporary.samplemessages.SampleMessages;
 
-import java.util.Properties;
-
-import org.apache.camel.PropertyInject;
-import org.apache.camel.builder.RouteBuilder;
-
 public class Route extends RouteBuilder {
+	/*
 
     @PropertyInject(value = "audience")
     private String audiences;
@@ -36,27 +36,28 @@ public class Route extends RouteBuilder {
     private String processingDomain;
     @PropertyInject(value = "version")
     private String version;
-    
+    */
 
-    public Route() {
-
-    }
 
     // PropertyInject doesn't seem to work in the unit tests, allows creation of the route setting this value
+	/*
     public Route(String validV2MessageTypes, String validReceivingFacility, String processingDomain, String version) {
         this.validV2MessageTypes = validV2MessageTypes;
         this.validReceivingFacility = validReceivingFacility;
         this.processingDomain = processingDomain;
         this.version = version;
     }
+    */
 
     @Override
     public void configure() {
     	injectProperties();
-        AuthorizationProperties authProperties = new AuthorizationProperties(audiences, authorizedParties, scopes, validV2MessageTypes, issuer, validReceivingFacility,processingDomain,version);
+        //AuthorizationProperties authProperties = new AuthorizationProperties(audiences, authorizedParties, scopes, validV2MessageTypes, issuer, validReceivingFacility,processingDomain,version);
         //TODO just pass auth properties into the method
-        V2PayloadValidator v2PayloadValidator = new V2PayloadValidator(authProperties);
-        ValidateAccessToken validateAccessToken = new ValidateAccessToken(authProperties, certsEndpoint);
+    	// TODO completed by using injecting properties    
+        V2PayloadValidator v2PayloadValidator = new V2PayloadValidator();
+        ValidateAccessToken validateAccessToken = new ValidateAccessToken();
+        
 
         // Handling custom exception  
         onException(CustomHNSException.class)
@@ -73,7 +74,7 @@ public class Route extends RouteBuilder {
             .process(validateAccessToken).id("ValidateAccessToken")
             .setBody().method(new FhirPayloadExtractor())
             .log("Decoded V2: ${body}")            
-            .bean(V2PayloadValidator.class).id("V2PayloadValidator")
+            .bean(v2PayloadValidator).id("V2PayloadValidator")
             //set the receiving app, message type into headers
             .bean(PopulateReqHeader.class).id("PopulateReqHeader")
             .to("log:HttpLogger?level=DEBUG&showBody=true&showHeaders=true&multiline=true")

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/Route.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/Route.java
@@ -20,14 +20,11 @@ public class Route extends RouteBuilder {
     @Override
     public void configure() {
     	injectProperties();
-        //AuthorizationProperties authProperties = new AuthorizationProperties(audiences, authorizedParties, scopes, validV2MessageTypes, issuer, validReceivingFacility,processingDomain,version);
-        // TODO just pass auth properties into the method
-    	// completed by using injecting properties    
+
         V2PayloadValidator v2PayloadValidator = new V2PayloadValidator();
         ValidateAccessToken validateAccessToken = new ValidateAccessToken();
         
-
-        // Handling custom exception  
+        // TODO Exception class name is not inline with other exception. It is generic name as compared to ValidationFailedException 
         onException(CustomHNSException.class)
         	.process(new ExceptionHandler())
         	.handled(true);
@@ -42,6 +39,7 @@ public class Route extends RouteBuilder {
             .process(validateAccessToken).id("ValidateAccessToken")
             .setBody().method(new FhirPayloadExtractor())
             .log("Decoded V2: ${body}")            
+            // TODO if Payload validator is called beforeFhirPayloadExtractor(), no need of separate validator in validateAccessToken 
             .bean(v2PayloadValidator).id("V2PayloadValidator")
             //set the receiving app, message type into headers
             .bean(PopulateReqHeader.class).id("PopulateReqHeader")

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/authorization/ValidateAccessToken.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/authorization/ValidateAccessToken.java
@@ -42,6 +42,7 @@ public class ValidateAccessToken implements Processor {
 
 	private static final Logger logger = LoggerFactory.getLogger(ValidateAccessToken.class);
 	private static final String AUTH_HEADER_KEY = "Authorization";
+	private static final String OBJECT_TYPE_JWT = "JWT";
 
 	private ApplicationProperties properties = ApplicationProperties.getInstance();
 	
@@ -62,7 +63,7 @@ public class ValidateAccessToken implements Processor {
 
 		// Create a JWT processor for the access tokens
 		ConfigurableJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();
-		jwtProcessor.setJWSTypeVerifier(new DefaultJOSEObjectTypeVerifier(new JOSEObjectType("JWT")));
+		jwtProcessor.setJWSTypeVerifier(new DefaultJOSEObjectTypeVerifier<>(new JOSEObjectType(OBJECT_TYPE_JWT)));
 		
 		String certEndpoints = properties.getValue(CERTS_ENDPOINT);
 
@@ -88,7 +89,7 @@ public class ValidateAccessToken implements Processor {
 
 		// Set the required JWT claims - these must all be available in the token payload
 		jwtProcessor.setJWTClaimsSetVerifier(
-				new CustomJWTClaimsVerifier(
+				new CustomJWTClaimsVerifier<>(
 						// Accepted Audience -> aud
 						audiences,
 						// Accepted Authorized Parties -> azp

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/authorization/ValidateAccessToken.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/authorization/ValidateAccessToken.java
@@ -1,5 +1,6 @@
 package ca.bc.gov.hlth.hnsecure.authorization;
 
+
 import java.net.URL;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -81,9 +82,7 @@ public class ValidateAccessToken implements Processor {
 		jwtProcessor.setJWSKeySelector(keySelector);
 		
 
-        //return audiences;
-    	String audience = properties.getValue(AUDIENCE);
-    	Set<String> audiences =  Util.getPropertyAsSet(audience);
+        Set<String> audiences =  Util.getPropertyAsSet(properties.getValue(AUDIENCE));
     	Set<String> authorizedParties = Util.getPropertyAsSet(properties.getValue(AUTHORIZED_PARTIES));
     	Set <String> scopes = Util.getPropertyAsSet(properties.getValue(SCOPES));
 

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/messagevalidation/ExceptionHandler.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/messagevalidation/ExceptionHandler.java
@@ -6,11 +6,11 @@ import org.apache.camel.Processor;
 import static ca.bc.gov.hlth.hnsecure.message.ErrorMessage.CustomError_Msg_InvalidAuthKey;
 
 /**
- * Custom validator added to verify access token in request
+ * Custom ExceptionHandler added to verify access token in request
  * @author pankaj.kathuria
  *
  */
-public class AccessValidator implements Processor {
+public class ExceptionHandler implements Processor {
 
 
     /**

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/PopulateReqHeader.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/PopulateReqHeader.java
@@ -31,7 +31,7 @@ public class PopulateReqHeader {
 	 * @throws Exception
 	 */
 	@Handler
-	public static void populateReqHeader(Exchange exchange, @Headers Map<String, String> hm, String v2Message)
+	public void populateReqHeader(Exchange exchange, @Headers Map<String, String> hm, String v2Message)
 			throws Exception {
 		String recApp = Util.getReceivingApp(v2Message);
 		String msgType = Util.getMsgType(v2Message);

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/Util.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/Util.java
@@ -1,25 +1,17 @@
 package ca.bc.gov.hlth.hnsecure.parsing;
 
+
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
-import java.text.SimpleDateFormat;
-import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Base64;
-import java.util.Calendar;
 import java.util.Collections;
-import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.TimeZone;
 
 public final class Util {
 

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/Util.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/Util.java
@@ -10,10 +10,15 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.TimeZone;
 
 public final class Util {
@@ -154,5 +159,29 @@ public final class Util {
 		return ZonedDateTime.now().format(FORMATTER);
 
 	}
+	
+    /**
+     * Return a list of values from a comma delimited property
+     * If string does not have 
+     * @param commaDelimitedProperties a String of comma delimited values
+     * @return List
+     */
+    public static List<String> getPropertyAsList(String commaDelimitedProperties) {
+        List<String> propertyList = Collections.emptyList();
+        if (commaDelimitedProperties != null && !commaDelimitedProperties.isBlank()) {
+            propertyList = Arrays.asList(commaDelimitedProperties.split("\\s*,\\s*"));
+        }
+        return propertyList;
+    }
+
+    /**
+     * Return a set of values from a comma delimited property
+     *
+     * @param commaDelimitedProperties a String of comma delimited values
+     * @return Set
+     */
+    public static Set<String> getPropertyAsSet(String commaDelimitedProperties) {
+        return new HashSet<>(getPropertyAsList(commaDelimitedProperties));
+    }
 
 }

--- a/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/authorization/ValidateAccessTokenTest.java
+++ b/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/authorization/ValidateAccessTokenTest.java
@@ -23,7 +23,7 @@ public class ValidateAccessTokenTest {
     private String jwtInvalidScopes;
     private String jwtInvalidIssuer;
 
-    private final ValidateAccessToken validateAccessToken = new ValidateAccessToken(authProps, certsEndpoint);
+    private final ValidateAccessToken validateAccessToken = new ValidateAccessToken();
     private Exchange exchange = new DefaultExchange(new DefaultCamelContext());
 
     @Test

--- a/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/authorization/ValidateAccessTokenTest.java
+++ b/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/authorization/ValidateAccessTokenTest.java
@@ -7,23 +7,12 @@ import org.junit.Test;
 
 public class ValidateAccessTokenTest {
 
-    private AuthorizationProperties authProps = new AuthorizationProperties(
-            "account",
-            "moh_hnclient_dev",
-            "system/*.write",
-            "r03, r07, r09",
-            "https://common-logon-dev.hlth.gov.bc.ca/auth/realms/v2_pos",
-            "",
-            "D"
-            ,"2.1");
-    private String certsEndpoint = null;
 
     private String jwtInvalidAud;
     private String jwtInvalidAuthParties;
     private String jwtInvalidScopes;
     private String jwtInvalidIssuer;
 
-    private final ValidateAccessToken validateAccessToken = new ValidateAccessToken();
     private Exchange exchange = new DefaultExchange(new DefaultCamelContext());
 
     @Test

--- a/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/messagevalidation/V2PayloadValidatorTest.java
+++ b/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/messagevalidation/V2PayloadValidatorTest.java
@@ -15,30 +15,11 @@ import org.junit.Test;
 import ca.bc.gov.hlth.hnsecure.message.ValidationFailedException;
 import ca.bc.gov.hlth.hnsecure.properties.ApplicationProperties;
 import ca.bc.gov.hlth.hnsecure.samplemessages.SamplesToSend;
+import ca.bc.gov.hlth.hnsecure.test.TestPropertiesLoader;
 
-public class V2PayloadValidatorTest {
+public class V2PayloadValidatorTest extends TestPropertiesLoader{
 
     private V2PayloadValidator v2PayloadValidator = new V2PayloadValidator();
-    private static CamelContext context = new DefaultCamelContext();
-    private Exchange exchange = new DefaultExchange(context);
-    
-    
-    
-    @BeforeClass
-	public static void loadProperties() throws Exception {
-    	// Since we're not running from the main we need to set the properties
-		PropertiesComponent pc = context.getPropertiesComponent();
-		pc.setLocation("classpath:application.properties"); // laoding properties in test/resources
-		ApplicationProperties properties = ApplicationProperties.getInstance() ;
-		properties.injectProperties(pc.loadProperties());
-		
-	}
-    
-    @AfterClass
-	public static void cleanUp() throws Exception {
-    	context.close();
-    	
-    }
     
     
     @Test

--- a/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/messagevalidation/V2PayloadValidatorTest.java
+++ b/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/messagevalidation/V2PayloadValidatorTest.java
@@ -1,33 +1,44 @@
 package ca.bc.gov.hlth.hnsecure.messagevalidation;
 
-import ca.bc.gov.hlth.hnsecure.authorization.AuthorizationProperties;
-import ca.bc.gov.hlth.hnsecure.message.ValidationFailedException;
-import ca.bc.gov.hlth.hnsecure.parsing.Util;
-import ca.bc.gov.hlth.hnsecure.samplemessages.SamplesToSend;
-
-import org.apache.camel.Exchange;
-import org.apache.camel.impl.DefaultCamelContext;
-import org.apache.camel.support.DefaultExchange;
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.spi.PropertiesComponent;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import ca.bc.gov.hlth.hnsecure.message.ValidationFailedException;
+import ca.bc.gov.hlth.hnsecure.properties.ApplicationProperties;
+import ca.bc.gov.hlth.hnsecure.samplemessages.SamplesToSend;
+
 public class V2PayloadValidatorTest {
 
-    private AuthorizationProperties authProps = new AuthorizationProperties(
-            "account",
-            "moh_hnclient_dev",
-            "system/*.write",
-            "r03",
-            "",
-            "BC00002041"
-            ,"D"
-            ,"2.1");
-
-    private final V2PayloadValidator v2PayloadValidator = new V2PayloadValidator(authProps);
- 
-    private Exchange exchange = new DefaultExchange(new DefaultCamelContext());
+    private V2PayloadValidator v2PayloadValidator = new V2PayloadValidator();
+    private static CamelContext context = new DefaultCamelContext();
+    private Exchange exchange = new DefaultExchange(context);
+    
+    
+    
+    @BeforeClass
+	public static void loadProperties() throws Exception {
+    	// Since we're not running from the main we need to set the properties
+		PropertiesComponent pc = context.getPropertiesComponent();
+		pc.setLocation("classpath:application.properties"); // laoding properties in test/resources
+		ApplicationProperties properties = ApplicationProperties.getInstance() ;
+		properties.injectProperties(pc.loadProperties());
+		
+	}
+    
+    @AfterClass
+	public static void cleanUp() throws Exception {
+    	context.close();
+    	
+    }
     
     
     @Test
@@ -100,7 +111,7 @@ public class V2PayloadValidatorTest {
     @Test
     public void testHL7ErrorMsgEncryptionError() {
     	exchange.getIn().setHeader("Authorization", SamplesToSend.AUTH_HEADER);
-    
+    	
         String msgInput="MSH|^~\\&|HNWeb|moh_hnclient_dev|RAIGT-PRSN-DMGR|BC0002041|20191108083244|train96|R03|20191108083244|D|2.4||\n" +
                 "ZHD|20191108083244|^^00000010|HNAIADMINISTRATION||||2.4\n" +
                 "PID||0000053655^^^BC^PH\n";

--- a/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/parsing/UtilTest.java
+++ b/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/parsing/UtilTest.java
@@ -5,9 +5,7 @@ package ca.bc.gov.hlth.hnsecure.parsing;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import java.io.UnsupportedEncodingException;
 
-import ca.bc.gov.hlth.hnsecure.parsing.Util;
 import org.junit.Test;
 
 /**

--- a/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/route/RouteTest.java
+++ b/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/route/RouteTest.java
@@ -40,17 +40,11 @@ public class RouteTest extends CamelTestSupport {
 
 		// Since we're not running from the main we need to set the properties
 		PropertiesComponent pc = context.getPropertiesComponent();
-		pc.setLocation("classpath:application.properties"); // laoding properties in test/resources
+		pc.setLocation("classpath:application.properties"); // loading properties in test/resources
 		ApplicationProperties properties = ApplicationProperties.getInstance() ;
 		properties.injectProperties(pc.loadProperties());
 		
-		
-		String validV2MessageTypes = properties.getValue(ApplicationProperty.VALID_V2_MSG_TYPES);
-		String validReceivingFacility = properties.getValue(ApplicationProperty.VALID_RECIEVING_FACILITY); 
-		String processingDomain = properties.getValue(ApplicationProperty.PROCESSING_DOMAIN);
-		String version = properties.getValue(ApplicationProperty.VERSION);
-		context.addRoutes(new Route( validV2MessageTypes,  validReceivingFacility,  processingDomain,  version));
-		
+		context.addRoutes(new Route());
 		AdviceWithRouteBuilder.adviceWith(context, "hnsecure-route", a -> {
 			a.replaceFromWith("direct:start");
 			a.weaveById("ValidateAccessToken").replace().to("mock:ValidateAccessToken");

--- a/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/test/TestPropertiesLoader.java
+++ b/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/test/TestPropertiesLoader.java
@@ -1,0 +1,36 @@
+package ca.bc.gov.hlth.hnsecure.test;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.spi.PropertiesComponent;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import ca.bc.gov.hlth.hnsecure.properties.ApplicationProperties;
+
+public class TestPropertiesLoader {
+
+	public static CamelContext context = new DefaultCamelContext();
+    public Exchange exchange = new DefaultExchange(context);
+
+	
+    @BeforeClass
+	public static void loadProperties() throws Exception {
+    	// Since we're not running from the main we need to set the properties
+		PropertiesComponent pc = context.getPropertiesComponent();
+		pc.setLocation("classpath:application.properties"); // laoding properties in test/resources
+		ApplicationProperties properties = ApplicationProperties.getInstance() ;
+		properties.injectProperties(pc.loadProperties());
+		
+	}
+    
+    @AfterClass
+	public static void cleanUp() throws Exception {
+    	context.close();
+    	
+    }
+
+
+}


### PR DESCRIPTION
Property injection was used in Route class to pass on the properties to other classes. Passing the values was divided in 2  types:
1. AuthorizationProperties was used as object of properties in application.properties
2. Some of the properties were passed directly to the constructors of required classes and some were set in AuthorizationProperties  and object of AuthorizationProperties  was passed.

In code refactoring, 
1. ApplicationProperty.java (enum) mapped to all the properties in application.properties. 
2. The properties from application.properties are loaded in ApplicationProperties object at startup of application. This object is available to all classes to read the property values from application.properties file. 
Cons:
* Single place holder for properties
* Injection happening at one place
* Properties are available to all classes, irrespective if it has access to CamelContext or not
