### PR TITLE
Hn secure validator framework update

### DIFF
--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/exception/CustomHNSException.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/exception/CustomHNSException.java
@@ -16,4 +16,9 @@ public class CustomHNSException extends Exception {
 		super(msg);
 	}
 	
+	
+	public CustomHNSException(String msg, Throwable t) {
+		super(msg, t);
+	}
+	
 }

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/Util.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/Util.java
@@ -10,6 +10,7 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public final class Util {
@@ -173,6 +174,22 @@ public final class Util {
      */
     public static Set<String> getPropertyAsSet(String commaDelimitedProperties) {
         return new HashSet<>(getPropertyAsList(commaDelimitedProperties));
+    }
+    
+    
+    /**
+     * This method uses StackWalker API to get the names of the current calling method 
+     * @return
+     */
+    public static String getMethodName() {
+    	StackWalker walker = StackWalker.getInstance();
+    	Optional<String> methodName = walker.walk(frames -> frames
+			.limit(2)
+			.skip(1) // to get name of caller
+			.findFirst()
+			.map(StackWalker.StackFrame::getMethodName)
+			);
+    	return methodName.orElse("Method name Unknnown");
     }
 
 }

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/AbstractValidator.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/AbstractValidator.java
@@ -4,6 +4,8 @@ import org.apache.camel.Exchange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import ca.bc.gov.hlth.hnsecure.parsing.Util;
+
 /**
  * abstract class to validate 
  * @author pankaj.kathuria
@@ -17,9 +19,9 @@ public abstract class AbstractValidator implements Validator {
 
 	@Override
 	public void process(Exchange exchange) throws Exception {
-		logger.info("AbstractValidator processing started");
+		logger.info("{} - AbstractValidator processing started",Util.getMethodName());
 		validate(exchange);
-		logger.info("AbstractValidator processing completed");
+		logger.info("{} - AbstractValidator processing completed",Util.getMethodName());
 	}
 
 	

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/AbstractValidator.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/AbstractValidator.java
@@ -1,0 +1,27 @@
+package ca.bc.gov.hlth.hnsecure.validation;
+
+import org.apache.camel.Exchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * abstract class to validate 
+ * @author pankaj.kathuria
+ *
+ */
+public abstract class AbstractValidator implements Validator {
+	private static final Logger logger = LoggerFactory.getLogger(AbstractValidator.class);
+
+	public AbstractValidator() {
+	}
+
+	@Override
+	public void process(Exchange exchange) throws Exception {
+		logger.info("AbstractValidator processing started");
+		validate(exchange);
+		logger.info("AbstractValidator processing completed");
+	}
+
+	
+	
+}

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/PayLoadValidator.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/PayLoadValidator.java
@@ -36,7 +36,7 @@ public class PayLoadValidator extends AbstractValidator {
 	private static final String expectedEncodingChar = "^~\\&";
 	private static final String segmentIdentifier = "MSH";
 	private static final JSONParser jsonParser = new JSONParser(JSONParser.DEFAULT_PERMISSIVE_MODE);
-	private ApplicationProperties properties = ApplicationProperties.getInstance();
+	private static final ApplicationProperties properties = ApplicationProperties.getInstance();
 	
 	private Validator validator;
 	

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/PayLoadValidator.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/PayLoadValidator.java
@@ -1,0 +1,293 @@
+package ca.bc.gov.hlth.hnsecure.validation;
+
+import static ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty.PROCESSING_DOMAIN;
+import static ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty.VALID_RECIEVING_FACILITY;
+import static ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty.VERSION;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Set;
+
+import org.apache.camel.Exchange;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ca.bc.gov.hlth.hnsecure.exception.ValidationFailedException;
+import ca.bc.gov.hlth.hnsecure.message.ErrorMessage;
+import ca.bc.gov.hlth.hnsecure.message.ErrorResponse;
+import ca.bc.gov.hlth.hnsecure.message.HL7Message;
+import ca.bc.gov.hlth.hnsecure.message.MessageUtil;
+import ca.bc.gov.hlth.hnsecure.message.PharmanetErrorResponse;
+import ca.bc.gov.hlth.hnsecure.parsing.Util;
+import ca.bc.gov.hlth.hnsecure.properties.ApplicationProperties;
+import net.minidev.json.JSONObject;
+import net.minidev.json.parser.JSONParser;
+
+/**
+ * This validator validates the payload i.e. HL7 V2 message It performs different types of validations on the message. 
+ * For instance vlaidation message format, valdating contents of the message etc If the validation fails, it generates ValidationFailedException
+ * This class is using decorator pattern. So validate method also makes a call to validate method of wrapped class passed in constructor.    
+ * @author pankaj.kathuria
+ *
+ */
+public class PayLoadValidator extends AbstractValidator {
+	private static final Logger logger = LoggerFactory.getLogger(PayLoadValidator.class);
+	private static final String expectedEncodingChar = "^~\\&";
+	private static final String segmentIdentifier = "MSH";
+	private static final JSONParser jsonParser = new JSONParser(JSONParser.DEFAULT_PERMISSIVE_MODE);
+	private ApplicationProperties properties = ApplicationProperties.getInstance();
+	
+	private Validator validator;
+	
+	public PayLoadValidator(Validator validator) {
+		super();
+		this.validator = validator;
+	}
+
+
+
+	@Override
+	public boolean validate(Exchange exchange) throws Exception {
+		logger.info("PayLoadValidator Validation started");
+		HL7Message messageObj = new HL7Message();
+		String accessToken = (String) exchange.getIn().getHeader("Authorization"); 
+		// Validate v2Message format
+		String v2Message = (String) exchange.getIn().getBody();
+		validateMessageFormat(exchange, v2Message, messageObj);
+		boolean isPharmanetMode = isPharmanet(messageObj);
+		validateSendingFacility(exchange, messageObj, accessToken, isPharmanetMode);
+		validateReceivingApp(exchange, messageObj);
+		validateReceivingFacility(exchange, messageObj);
+		// TODO ADDRESSED  Do we need to populate fields in validator? Should this be done after validation is complete?
+		// This was populating fields for generating error message. So renamed the method and moved the call of populating extra fields where error generation is happening 
+		validatePhanrmanetMessageFormat(exchange, v2Message, messageObj, isPharmanetMode);
+		// To ensure validation in wrapper class is called.
+		validator.validate(exchange);
+		logger.info("PayLoadValidator Validation completed");
+		return true;
+	}
+
+	
+	/**
+	 * Validates the format of Pharmanet message
+	 * checks if zcb segment is present
+	 * @param exchange
+	 * @param v2Message
+	 * @param messageObj
+	 * @param isPharmanetMode
+	 * @throws ValidationFailedException
+	 */
+	protected  void validatePhanrmanetMessageFormat(Exchange exchange, String v2Message, HL7Message messageObj,
+			boolean isPharmanetMode) throws ValidationFailedException {
+		if (isPharmanetMode) {
+			if (!Util.isSegmentPresent(v2Message, Util.ZCB_SEGMENT)) {
+				populateFieldsForErrorResponse(messageObj);
+				generatePharmanetError(messageObj, ErrorMessage.HL7Error_Msg_TransactionFromatError, exchange);
+			}
+		}
+	}
+
+	/**
+	 * Validates the receiving facility for non-pharmanet messages.
+	 * Message type must be 'ZPN' for Pharmanet messages
+	 * @param exchange
+	 * @param messageObj
+	 * @throws ValidationFailedException
+	 */
+	protected  void validateReceivingFacility(Exchange exchange, HL7Message messageObj)
+			throws ValidationFailedException {
+		if (!messageObj.getReceivingApplication().equalsIgnoreCase(Util.RECEIVING_APP_PNP)) {
+			Set<String> validReceivingFacility = Util.getPropertyAsSet(properties.getValue(VALID_RECIEVING_FACILITY));
+			if (validReceivingFacility.stream().noneMatch(messageObj.getReceivingFacility()::equalsIgnoreCase)) {
+				generateError(messageObj, ErrorMessage.HL7Error_Msg_EncryptionError, exchange);
+
+			}
+		}else if (messageObj.getReceivingApplication().equalsIgnoreCase(Util.RECEIVING_APP_PNP)
+					&& (!messageObj.getMessageType().equalsIgnoreCase(Util.MESSAGE_TYPE_PNP))) {
+				generatePharmanetError(messageObj, ErrorMessage.HL7Error_Msg_EncryptionError, exchange);
+			}
+	}
+	
+
+	/**
+	 * Validates receiving application
+	 * @param exchange
+	 * @param messageObj
+	 * @throws ValidationFailedException
+	 */
+	protected  void validateReceivingApp(Exchange exchange, HL7Message messageObj)
+			throws ValidationFailedException {
+		if ((StringUtils.isEmpty(messageObj.getReceivingApplication())
+				|| StringUtils.isEmpty(messageObj.getReceivingFacility()))) {
+
+			generateError(messageObj, ErrorMessage.HL7Error_Msg_InvalidHL7Format, exchange);
+		}
+
+		// Check the validity
+		if (!MessageUtil.mTypeCollection.containsValue(messageObj.getReceivingApplication())) {
+			generateError(messageObj, ErrorMessage.HL7Error_Msg_UnknownReceivingApplication, exchange);
+		}
+	}
+
+	/**
+	 * This method checks if the sending facility provided in message is same as the facility in access token
+	 * If sending facility is not provided in the message, retrieve the facility from access token
+	 * Validation fails if the sending facility is not same as the facility in access token
+	 * @param exchange
+	 * @param messageObj
+	 * @param accessToken
+	 * @param isPharmanetMode
+	 * @throws ValidationFailedException
+	 */
+	protected  void validateSendingFacility(Exchange exchange, HL7Message messageObj, String accessToken,
+			boolean isPharmanetMode) throws ValidationFailedException {
+		// Validate Sending facility	
+		String facilityNameFromAccessToken = getSendingFacility(accessToken);
+		if (StringUtils.isEmpty(messageObj.getSendingFacility())) {
+			messageObj.setSendingFacility(facilityNameFromAccessToken);
+		} 
+		else if(!messageObj.getSendingFacility().equals(facilityNameFromAccessToken)) {
+			if(isPharmanetMode) {
+				generatePharmanetError(messageObj, ErrorMessage.HL7Error_Msg_FacilityIDMismatch, exchange);
+			}else {
+				generateError(messageObj, ErrorMessage.HL7Error_Msg_FacilityIDMismatch, exchange);
+			}
+		}
+		else {
+			//do nothing
+		}
+	}
+
+	/**
+	 * This method checks the format of incoming message
+	 * @param exchange
+	 * @param v2Message
+	 * @param messageObj
+	 * @throws ValidationFailedException
+	 */
+	protected  void validateMessageFormat(Exchange exchange, String v2Message, HL7Message messageObj)
+			throws ValidationFailedException {
+		if (!StringUtils.isEmpty(v2Message)) {
+			String[] v2DataLines = v2Message.split("\n");
+			String[] v2Segments = v2DataLines[0].split(Util.DOUBLE_BACKSLASH + Util.HL7_DELIMITER,-1);
+			if (Arrays.stream(v2Segments).allMatch(Objects::nonNull) && v2Segments.length >= 12) {
+				ErrorResponse.initSegment(v2Segments, messageObj);
+			} else {
+				generateError(messageObj, ErrorMessage.HL7Error_Msg_InvalidHL7Format, exchange);
+			}
+		} else {
+			generateError(messageObj, ErrorMessage.HL7Error_Msg_InvalidHL7Format, exchange);
+		}
+
+		// Validate segment identifier
+		if (!messageObj.getSegmentIdentifier().equals(segmentIdentifier)) {
+			generateError(messageObj, ErrorMessage.HL7Error_Msg_InvalidHL7Format, exchange);
+		}
+
+		// Validate encoding characters
+		if (StringUtils.isEmpty(messageObj.getEncodingCharacter())
+				|| messageObj.getEncodingCharacter().toCharArray().length != 4) {
+			generateError(messageObj, ErrorMessage.HL7Error_Msg_InvalidHL7Format, exchange);
+		} else if (!sameChars(messageObj.getEncodingCharacter(), expectedEncodingChar)) {
+			generateError(messageObj, ErrorMessage.HL7Error_Msg_InvalidMSHSegment, exchange);
+		}
+	}
+	
+	/**
+	 * This method checks if it is a Pharmanet message
+	 * @param messageObj
+	 * @return
+	 */
+	protected static boolean isPharmanet(HL7Message messageObj) {
+		if ((!StringUtils.isEmpty(messageObj.getMessageType())
+				&& (messageObj.getMessageType()).equals(Util.MESSAGE_TYPE_PNP))) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Populate optional field from properties file if present
+	 * @param messageObj
+	 */
+	private void populateFieldsForErrorResponse(HL7Message messageObj) {
+
+		if (StringUtils.isEmpty(messageObj.getDateTime())) {
+			messageObj.setDateTime(Util.getGenericDateTime());
+		}
+
+		if (StringUtils.isEmpty(messageObj.getVersionId())) {
+			messageObj.setVersionId(properties.getValue(VERSION));
+		}
+
+		if (StringUtils.isEmpty(messageObj.getProcessingId())) {
+			messageObj.setProcessingId(properties.getValue(PROCESSING_DOMAIN));
+		}
+	}
+
+	/**
+	 * @param messageObject
+	 * @param errorMessage
+	 * @param exchange
+	 * @throws ValidationFailedException
+	 */
+	private static void generateError(HL7Message messageObject, ErrorMessage errorMessage, Exchange exchange)
+			throws ValidationFailedException {
+		String methodName = "generateError";
+		messageObject.setReceivingApplication(Util.RECEIVING_APP_HNSECURE);
+		ErrorResponse errorResponse = new ErrorResponse();		
+		String v2Response = errorResponse.constructResponse(messageObject, errorMessage);
+		logger.info("{} - TransactionId: {}, FacilityId: {}, Error message is: {}",methodName, exchange.getIn().getMessageId(),messageObject.getSendingFacility(), errorMessage);
+		exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, 200);
+		exchange.getIn().setBody(v2Response);
+		throw new ValidationFailedException(errorMessage.getErrorMessage());
+	}
+
+	/**
+	 * @param messageObject
+	 * @param errorMessage
+	 * @param exchange
+	 * @throws ValidationFailedException
+	 */
+	private static void generatePharmanetError(HL7Message messageObject, ErrorMessage errorMessage, Exchange exchange)
+			throws ValidationFailedException {
+		String methodName = "generatePharmanetError";
+		messageObject.setReceivingApplication(Util.RECEIVING_APP_HNSECURE);
+		PharmanetErrorResponse errorResponse = new PharmanetErrorResponse();
+		String v2Response = errorResponse.constructResponse(messageObject, errorMessage);
+		logger.info("{} - TransactionId: {}, FacilityId: {}, Error message is: {}",methodName, exchange.getIn().getMessageId(),messageObject.getSendingFacility(), errorMessage);
+		exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, 200);
+		exchange.getIn().setBody(v2Response);
+		throw new ValidationFailedException(errorMessage.getErrorMessage());
+	}
+
+	/*
+	 * The FacilityId is the legacy way to track connected clients and is now set as
+	 * the ClientId of the client application In the access token this is the 'azp'
+	 * field
+	 */
+	private static String getSendingFacility(String auth) {
+		String clientId = "";
+		if (!StringUtils.isEmpty(auth)) {
+			String[] split = auth.split("\\.");
+			String decodeAuth = Util.decodeBase64(split[1]);
+			try {
+				JSONObject jsonObject = (JSONObject) jsonParser.parse(decodeAuth);
+				clientId = (String) jsonObject.get("azp");
+			} catch (net.minidev.json.parser.ParseException e) {
+				logger.error(e.getMessage());
+			}
+		}
+		return clientId;
+	}
+
+
+	private static boolean sameChars(String firstStr, String secondStr) {
+		char[] first = firstStr.toCharArray();
+		char[] second = secondStr.toCharArray();
+		Arrays.sort(first);
+		Arrays.sort(second);
+		return Arrays.equals(first, second);
+	}
+}

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/PayLoadValidator.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/PayLoadValidator.java
@@ -49,7 +49,8 @@ public class PayLoadValidator extends AbstractValidator {
 
 	@Override
 	public boolean validate(Exchange exchange) throws Exception {
-		logger.info("PayLoadValidator Validation started");
+		String methodName = Util.getMethodName();
+		logger.info("{} - PayLoadValidator Validation started",methodName);
 		HL7Message messageObj = new HL7Message();
 		String accessToken = (String) exchange.getIn().getHeader("Authorization"); 
 		// Validate v2Message format
@@ -64,7 +65,7 @@ public class PayLoadValidator extends AbstractValidator {
 		validatePhanrmanetMessageFormat(exchange, v2Message, messageObj, isPharmanetMode);
 		// To ensure validation in wrapper class is called.
 		validator.validate(exchange);
-		logger.info("PayLoadValidator Validation completed");
+		logger.info("{} - PayLoadValidator Validation completed",methodName);
 		return true;
 	}
 
@@ -234,7 +235,7 @@ public class PayLoadValidator extends AbstractValidator {
 	 */
 	private static void generateError(HL7Message messageObject, ErrorMessage errorMessage, Exchange exchange)
 			throws ValidationFailedException {
-		String methodName = "generateError";
+		String methodName = Util.getMethodName();
 		messageObject.setReceivingApplication(Util.RECEIVING_APP_HNSECURE);
 		ErrorResponse errorResponse = new ErrorResponse();		
 		String v2Response = errorResponse.constructResponse(messageObject, errorMessage);
@@ -252,7 +253,7 @@ public class PayLoadValidator extends AbstractValidator {
 	 */
 	private static void generatePharmanetError(HL7Message messageObject, ErrorMessage errorMessage, Exchange exchange)
 			throws ValidationFailedException {
-		String methodName = "generatePharmanetError";
+		String methodName = Util.getMethodName();
 		messageObject.setReceivingApplication(Util.RECEIVING_APP_HNSECURE);
 		PharmanetErrorResponse errorResponse = new PharmanetErrorResponse();
 		String v2Response = errorResponse.constructResponse(messageObject, errorMessage);

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/TokenValidator.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/TokenValidator.java
@@ -1,0 +1,151 @@
+package ca.bc.gov.hlth.hnsecure.validation;
+
+import static ca.bc.gov.hlth.hnsecure.message.ErrorMessage.CustomError_Msg_InvalidAuthKey;
+import static ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty.AUDIENCE;
+import static ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty.AUTHORIZED_PARTIES;
+import static ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty.CERTS_ENDPOINT;
+import static ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty.ISSUER;
+import static ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty.SCOPES;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.camel.Exchange;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.jwk.source.RemoteJWKSet;
+import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier;
+import com.nimbusds.jose.proc.JWSKeySelector;
+import com.nimbusds.jose.proc.JWSVerificationKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jose.util.DefaultResourceRetriever;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+
+import ca.bc.gov.hlth.hnsecure.authorization.CustomJWTClaimsVerifier;
+import ca.bc.gov.hlth.hnsecure.exception.CustomHNSException;
+import ca.bc.gov.hlth.hnsecure.parsing.Util;
+import ca.bc.gov.hlth.hnsecure.properties.ApplicationProperties;
+
+
+/**
+ * This class validate the token passed in the request using JSON Web Token processor
+ * JWT initialization is done in the constructor. 
+ * Our custom JWT claims verifier is used to validate access token against the Keycloak endpoint (provided in application properties). 
+ * @author pankaj.kathuria
+ *
+ */
+public class TokenValidator extends AbstractValidator {
+	private static final Logger logger = LoggerFactory.getLogger(TokenValidator.class);
+	private static final String AUTH_HEADER_KEY = "Authorization";
+	private static final String OBJECT_TYPE_JWT = "JWT";
+	
+	private ConfigurableJWTProcessor<SecurityContext> jwtProcessor;
+
+	private ApplicationProperties properties = ApplicationProperties.getInstance();
+	private Validator validator;
+	
+	
+	public TokenValidator(Validator validator) throws MalformedURLException {
+		super();
+		this.validator = validator;
+		jwtProcessor = initJwtProcessor();
+	}
+
+	@Override
+	public boolean validate(Exchange exchange) throws Exception {
+		logger.info("TokenValidator validation started");
+
+		String methodName = "validate";
+		
+		// If more validataion is required for exchange message, we should create a new bean
+		String authorizationKey = (String) exchange.getIn().getHeader(AUTH_HEADER_KEY);
+		if(StringUtils.isBlank(authorizationKey)) {
+			logger.info("{} - TransactionId: {}, No authorization key passed in request header.", methodName, exchange.getIn().getMessageId());
+			throw new CustomHNSException(CustomError_Msg_InvalidAuthKey.getErrorMessage());
+		}
+		AccessToken accessToken = AccessToken.parse(authorizationKey);
+		logger.info("{} - TransactionId: {}, Access token: {}", methodName,exchange.getIn().getMessageId(),accessToken);
+
+		// Process the token
+		JWTClaimsSet claimsSet = jwtProcessor.process(accessToken.toString(), null);
+
+		// Print out the token claims set
+		logger.info("{} - TransactionId: {}, TOKEN PAYLOAD: {}", methodName, exchange.getIn().getMessageId(), claimsSet.toJSONObject());
+	
+		logger.info("TokenValidator Validation completed");
+		// After token call the  other validations. Type of validation depends on wrapped class when initializing
+		validator.validate(exchange);
+	
+		return true;
+	}
+	
+	/**
+	 * This method configures the JSON Web token processor. 
+	 * This token processor will validate the access token passed in the request 
+	 * @throws MalformedURLException 
+	 */
+	protected ConfigurableJWTProcessor<SecurityContext> initJwtProcessor() throws MalformedURLException {
+		String methodName = "initJwtProcessor";
+		logger.info("{} - Loading JWT processor started.",methodName);
+		// Create a JWT processor for the access tokens
+		jwtProcessor = new DefaultJWTProcessor<>();
+		jwtProcessor.setJWSTypeVerifier(new DefaultJOSEObjectTypeVerifier<>(new JOSEObjectType(OBJECT_TYPE_JWT)));
+		
+		String certEndpoints = properties.getValue(CERTS_ENDPOINT);
+
+		// The public RSA keys to validate the signatures
+		// The RemoteJWKSet caches the retrieved keys to speed up subsequent look-ups
+		JWSAlgorithm expectedJWSAlg = JWSAlgorithm.RS256;
+		JWKSource<SecurityContext> keySource = new RemoteJWKSet<>(
+				new URL(certEndpoints),
+				// Overrides the DefaultResourceRetriever to up the timeouts to 5 seconds
+				new DefaultResourceRetriever(5000, 5000, 51200)
+				);
+		
+		// Configure the JWT processor with a key selector to feed matching public
+		// RSA keys sourced from the JWK set URL
+		JWSKeySelector<SecurityContext> keySelector = new JWSVerificationKeySelector<>(expectedJWSAlg, keySource);
+		jwtProcessor.setJWSKeySelector(keySelector);
+		
+
+        Set<String> audiences =  Util.getPropertyAsSet(properties.getValue(AUDIENCE));
+    	Set<String> authorizedParties = Util.getPropertyAsSet(properties.getValue(AUTHORIZED_PARTIES));
+    	Set <String> scopes = Util.getPropertyAsSet(properties.getValue(SCOPES));
+
+		// Set the required JWT claims - these must all be available in the token payload
+		jwtProcessor.setJWTClaimsSetVerifier(
+				new CustomJWTClaimsVerifier<>(
+						// Accepted Audience -> aud
+						audiences,
+						// Accepted Authorized Parties -> azp
+						authorizedParties,
+						// Accepted Scopes -> scope
+						scopes,
+						// Exact Match Claims -> iss
+						new JWTClaimsSet.Builder()
+						.issuer(properties.getValue(ISSUER))
+						.build(),
+						// Required Claims -> azp, scope, iat, exp, jti
+						new HashSet<>(Arrays.asList("azp", "scope", "iat", "exp", "jti")),
+						// Prohibited Claims
+						null
+						)
+				);
+		logger.info("{} - Loading JWT processor completed.",methodName);
+		return jwtProcessor;
+	}
+
+
+
+}

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/TokenValidator.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/TokenValidator.java
@@ -96,7 +96,7 @@ public class TokenValidator extends AbstractValidator {
 	 * @throws MalformedURLException 
 	 */
 	protected ConfigurableJWTProcessor<SecurityContext> initJwtProcessor() throws MalformedURLException {
-		String methodName = "initJwtProcessor";
+		String methodName = Util.getMethodName();
 		logger.info("{} - Loading JWT processor started.",methodName);
 		// Create a JWT processor for the access tokens
 		jwtProcessor = new DefaultJWTProcessor<>();

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/TokenValidator.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/TokenValidator.java
@@ -49,10 +49,11 @@ public class TokenValidator extends AbstractValidator {
 	private static final Logger logger = LoggerFactory.getLogger(TokenValidator.class);
 	private static final String AUTH_HEADER_KEY = "Authorization";
 	private static final String OBJECT_TYPE_JWT = "JWT";
+	private ApplicationProperties properties = ApplicationProperties.getInstance();
 	
 	private ConfigurableJWTProcessor<SecurityContext> jwtProcessor;
 
-	private ApplicationProperties properties = ApplicationProperties.getInstance();
+	
 	private Validator validator;
 	
 	
@@ -66,7 +67,7 @@ public class TokenValidator extends AbstractValidator {
 	public boolean validate(Exchange exchange) throws Exception {
 		logger.info("TokenValidator validation started");
 
-		String methodName = "validate";
+		String methodName = Util.getMethodName();
 		
 		// If more validataion is required for exchange message, we should create a new bean
 		String authorizationKey = (String) exchange.getIn().getHeader(AUTH_HEADER_KEY);

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/Validator.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/Validator.java
@@ -1,0 +1,22 @@
+package ca.bc.gov.hlth.hnsecure.validation;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+
+/**
+ * This interface uses decorator pattern for adding validation in HNSecure
+ * Abstract implementation of Validator should extend this interface
+ * Reference: AbstractValidator.java
+ * @author pankaj.kathuria
+ *
+ */
+public interface Validator extends Processor {
+	
+	/**
+	 * Returning boolean in case we have to catch exception and throw custom exception in process method.
+	 * For future usage we can also return ValidationStatus object having attributes like status, failure messages in case of failures
+	 * @throws Exception 
+	 */
+	public boolean validate(Exchange exchange) throws Exception;
+	
+}

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/ValidatorImpl.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/ValidatorImpl.java
@@ -1,0 +1,43 @@
+package ca.bc.gov.hlth.hnsecure.validation;
+
+
+import org.apache.camel.Exchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is the implementation class of decorator pattern interface
+ * It can have an non-argument constructor, so this will be used as innermost argument in calling the validators
+ * for example: Validator validator = new PayLoadValidator(new TokenValidator(new ValidatorImpl()));
+ * In this order of invocation, initialization is happening in the order of
+ * 1. PayLoadValidator
+ * 2. TokenValidator
+ * 3. ValidatorImpl
+ * @author pankaj.kathuria
+ *
+ */
+
+public class ValidatorImpl implements Validator {
+	
+	Logger logger = LoggerFactory.getLogger(ValidatorImpl.class);
+	
+	@Override
+	public void process(Exchange exchange) throws Exception {
+		logger.info("Validation processing started");
+	}
+
+	/**
+	 * Currently this implementation does nothing to validate as we are using this implementation as innermost
+	 * If a common validation is required for all the validators, we can move that business logic to this method.
+	 * 
+	 */
+	@Override
+	public boolean validate(Exchange exchange) {
+		logger.info("Inner validation processing started");
+		logger.info("Inner validation processing complete");
+		return true;
+	}
+
+	
+	
+}

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/ValidatorImpl.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/ValidatorImpl.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
 
 public class ValidatorImpl implements Validator {
 	
-	Logger logger = LoggerFactory.getLogger(ValidatorImpl.class);
+	private static final Logger logger = LoggerFactory.getLogger(ValidatorImpl.class);
 	
 	@Override
 	public void process(Exchange exchange) throws Exception {

--- a/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/validation/PayLoadValidatorTest.java
+++ b/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/validation/PayLoadValidatorTest.java
@@ -1,0 +1,182 @@
+package ca.bc.gov.hlth.hnsecure.validation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
+
+import org.apache.camel.Exchange;
+import org.junit.Test;
+
+import ca.bc.gov.hlth.hnsecure.exception.ValidationFailedException;
+import ca.bc.gov.hlth.hnsecure.samplemessages.SamplesToSend;
+import ca.bc.gov.hlth.hnsecure.test.TestPropertiesLoader;
+
+public class PayLoadValidatorTest extends TestPropertiesLoader {
+
+    private PayLoadValidator v2PayloadValidator = new PayLoadValidator(new ValidatorImpl());
+    
+    
+    @Test
+    public void testHL7ErrorMsgInvalidHL7Format() {
+    	String expectedResponse = "MSA|AR||VLDT014E  The Supplied HL7 Message was improperly formatted|";
+    	exchange.getIn().setBody(SamplesToSend.msgInvalidFormat);
+        assertThrows(ValidationFailedException.class, () -> {
+            v2PayloadValidator.validate(exchange);
+        });
+
+        assertEquals(exchange.getIn().getHeader(Exchange.HTTP_RESPONSE_CODE), 200);
+        String response = ((String) exchange.getIn().getBody()).split("\n")[1];
+        assertEquals(response,expectedResponse);       
+    }
+    
+    @Test
+    public void testHL7ErrorMsgInvalidHL7FormatMissingEncodingChar() throws ValidationFailedException {
+    	String expectedResponse = "MSA|AR|20191108083244|VLDT014E  The Supplied HL7 Message was improperly formatted|";
+    	exchange.getIn().setBody(SamplesToSend.msgMissingEncodingChar);
+        assertThrows(ValidationFailedException.class, () -> {
+            v2PayloadValidator.validate(exchange );
+        });
+        assertEquals(exchange.getIn().getHeader(Exchange.HTTP_RESPONSE_CODE), 200);
+        String response = ((String) exchange.getIn().getBody()).split("\n")[1];
+        assertEquals(response,expectedResponse);       
+    }
+    
+    @Test
+    public void testHL7ErrorMsgNoInputHL7() throws ValidationFailedException {
+    	String expectedResponse = "MSA|AR||VLDT014E  The Supplied HL7 Message was improperly formatted|";
+    	exchange.getIn().setBody(null);
+        assertThrows(ValidationFailedException.class, () -> {
+            v2PayloadValidator.validate(exchange);
+        });
+        assertEquals(exchange.getIn().getHeader(Exchange.HTTP_RESPONSE_CODE), 200);
+        String response = ((String) exchange.getIn().getBody()).split("\n")[1];
+        assertEquals(response,expectedResponse);       
+    }
+    
+    @Test
+    public void testHL7ErrorMsgMSHSegmentMissing() {
+    	String expectedResponse = "MSA|AR|20191108083244|VLDT014E  The Supplied HL7 Message was improperly formatted|";
+    	exchange.getIn().setBody(SamplesToSend.msgInvalidMSH);
+    	assertThrows(ValidationFailedException.class, () -> {
+            v2PayloadValidator.validate(exchange);
+        });
+        assertEquals(exchange.getIn().getHeader(Exchange.HTTP_RESPONSE_CODE), 200);
+        String response = ((String) exchange.getIn().getBody()).split("\n")[1];
+        assertEquals(response,expectedResponse);       
+    }
+    
+
+
+    @Test
+    public void testHL7ErrorMsgFacilityIdMismatch() {
+    
+        String msgInput="MSH|^~\\&|HNWeb|BC01000030|RAIGT-PRSN-DMGR|BC00002041|20191108083244|train96|R03|20191108083244|D|2.4||\n" +
+                "ZHD|20191108083244|^^00000010|HNAIADMINISTRATION||||2.4\n" +
+                "PID||0000053655^^^BC^PH\n";
+    	String expectedResponse = "MSA|AR|20191108083244|VLDT008E  The Client Facility and HL7 Sending Facility IDs do not match.|";
+    	exchange.getIn().setBody(msgInput);
+    	assertThrows(ValidationFailedException.class, () -> {
+            v2PayloadValidator.validate(exchange);
+        });
+        assertEquals(exchange.getIn().getHeader(Exchange.HTTP_RESPONSE_CODE), 200);
+        String response = ((String) exchange.getIn().getBody()).split("\n")[1];
+        assertEquals(response,expectedResponse);       
+    }
+    
+    @Test
+    public void testHL7ErrorMsgEncryptionError() {
+    	exchange.getIn().setHeader("Authorization", SamplesToSend.AUTH_HEADER);
+    	
+        String msgInput="MSH|^~\\&|HNWeb|moh_hnclient_dev|RAIGT-PRSN-DMGR|BC0002041|20191108083244|train96|R03|20191108083244|D|2.4||\n" +
+                "ZHD|20191108083244|^^00000010|HNAIADMINISTRATION||||2.4\n" +
+                "PID||0000053655^^^BC^PH\n";
+    	String expectedResponse = "MSA|AR|20191108083244|TXFR029E  Encryption protocols failed with remote facility.|";
+    	exchange.getIn().setBody(msgInput);
+    	assertThrows(ValidationFailedException.class, () -> {
+            v2PayloadValidator.validate(exchange);
+        });
+        assertEquals(exchange.getIn().getHeader(Exchange.HTTP_RESPONSE_CODE), 200);
+        String response = ((String) exchange.getIn().getBody()).split("\n")[1];
+        assertEquals(response,expectedResponse);       
+    }
+    
+    @Test
+    public void testHL7ErrorMsgEncryptionErrorPharmanet() {
+    	exchange.getIn().setHeader("Authorization", SamplesToSend.AUTH_HEADER);
+    
+        String msgInput="MSH|^&~\\|DESKTOP|moh_hnclient_dev|PNP|PP|2012/01/06 15:47:24|SS0AR|ZP|000008|D|2.1||\r\n"+
+        		"ZZZ|TRP|R|000008|P1|XXASD||||\r\n"+
+        		"ZCA|000001|03|00|AR|04|\r\n"+
+        		"ZCB|BC000001AB|210405|000008\n"+
+        		"ZCC||||||||||0009735391361|\r\n";
+    	String expectedResponse = "ZZZ||1|||||TXFR029E  Encryption protocols failed with remote facility.||";
+    	exchange.getIn().setBody(msgInput);
+    	assertThrows(ValidationFailedException.class, () -> {
+            v2PayloadValidator.validate(exchange);
+        });
+        assertEquals(exchange.getIn().getHeader(Exchange.HTTP_RESPONSE_CODE), 200);
+        String response = ((String) exchange.getIn().getBody()).split("\n")[3];
+        assertEquals(response,expectedResponse);       
+    }
+    
+    
+    @Test
+    public void testHL7ErrorMsgTransactionFromatError() {
+    	exchange.getIn().setHeader("Authorization", SamplesToSend.AUTH_HEADER);
+    	
+        String msgInput="MSH|^&~\\|DESKTOP|moh_hnclient_dev|PNP|PP|2012/01/06 15:47:24|SS0AR|ZPN|000008|D|2.1||\n"+
+        		"ZZZ|TRP|R|000008|P1|XXASD||||\n"+
+        		"ZCA|000001|03|00|AR|04|\n"+
+        		"ZCC||||||||||0009735391361|\n";
+        
+    	String expectedResponse = "ZZZ||1|||||PNPA004E  Transaction format error detected||";
+    	exchange.getIn().setBody(msgInput);
+    	assertThrows(ValidationFailedException.class, () -> {
+            v2PayloadValidator.validate(exchange);
+        });
+        assertEquals(exchange.getIn().getHeader(Exchange.HTTP_RESPONSE_CODE), 200);
+        String response = ((String) exchange.getIn().getBody()).split("\n")[3];
+        assertEquals(response,expectedResponse);        
+       
+    }
+    
+    
+    @Test
+    public void testPNPMessageFormat() {
+    	exchange.getIn().setHeader("Authorization", SamplesToSend.AUTH_HEADER);
+        String msgInput="MSH|^&~\\|DESKTOP|moh_hnclient_dev|PNP|PP|2012/01/06 15:47:24|SS0AR|ZPN|000008|D|2.1||\r\n"+
+        		"ZZZ|TRP|R|000008|P1|XXASD||||\r\n"+
+        		"ZCA|000001|03|00|AR|04|\r\n"+
+        		"ZCC||||||||||0009735391361|\r\n";
+        
+    	String expectedZCA ="ZCA|||50|||" ;
+    	String expectedZCB ="ZCB|||" ; 
+    	String expectedZZZ ="ZZZ||1|||||PNPA004E  Transaction format error detected||" ; 
+    	exchange.getIn().setBody(msgInput);		
+    	assertThrows(ValidationFailedException.class, () -> {
+            v2PayloadValidator.validate(exchange);
+        });
+        assertEquals(exchange.getIn().getHeader(Exchange.HTTP_RESPONSE_CODE), 200);
+        String zca = ((String) exchange.getIn().getBody()).split("\n")[1];
+        assertEquals(zca,expectedZCA);
+        
+        String zcb = ((String) exchange.getIn().getBody()).split("\n")[2];
+        assertEquals(zcb,expectedZCB);
+        
+        String zzz = ((String) exchange.getIn().getBody()).split("\n")[3];
+        assertEquals(zzz,expectedZZZ);
+        
+    }
+
+    // Validate no exception is thrown
+    @Test  
+    public void testValidMessage() {
+    	exchange.getIn().setHeader("Authorization", SamplesToSend.AUTH_HEADER);
+    	exchange.getIn().setBody(SamplesToSend.msgR03);
+    	try {
+    		v2PayloadValidator.validate(exchange);
+    	}catch(Exception e) {
+    		fail("Not expecting exception ");
+    	}
+    }
+}

--- a/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/validation/TokenValidatorTest.java
+++ b/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/validation/TokenValidatorTest.java
@@ -1,0 +1,72 @@
+package ca.bc.gov.hlth.hnsecure.validation;
+
+
+import static org.junit.Assert.fail;
+
+import java.net.MalformedURLException;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.Test;
+
+import ca.bc.gov.hlth.hnsecure.exception.CustomHNSException;
+import ca.bc.gov.hlth.hnsecure.test.TestPropertiesLoader;
+
+public class TokenValidatorTest extends TestPropertiesLoader {
+
+
+    private String jwtInvalidScopes;
+    private String jwtInvalidIssuer;
+
+    private Exchange exchange = new DefaultExchange(new DefaultCamelContext());
+
+    @Test
+    public void initialiazionSuccesful() {
+        try {
+			new TokenValidator(new ValidatorImpl());
+		} catch (MalformedURLException e) {
+			fail("Not expecting exception");
+		}
+    }
+
+    /**
+     * If Authorization header is not set, expect custom exception
+     */
+    @Test
+    public void blankAuthorizationHeader() {
+        exchange.getIn().setHeader("Authorization", null);
+        try {
+        	Validator validator = new TokenValidator(new ValidatorImpl());
+        	validator.validate(exchange);
+        	fail("Expecting CustomHNSException exception");
+        }catch(CustomHNSException e) {
+        	// Do nothing as expecting this exception
+        } catch (Exception e) {
+        	fail("Expecting CustomHNSException exception");
+		}
+        
+    }
+
+    @Test
+    public void invalidScopesTest() {
+        exchange.getIn().setHeader("Authorization", jwtInvalidScopes);
+    }
+
+    @Test
+    public void invalidIssuerTest() {
+        exchange.getIn().setHeader("Authorization", jwtInvalidIssuer);
+    }
+    
+    @Test
+    public void invalidTokenTest() {
+        exchange.getIn().setHeader("Authorization", "jwtInvalidToken");
+    }
+    
+    @Test
+    public void validTokenTest() {
+        exchange.getIn().setHeader("Authorization", "jwtValidToken");
+    }
+    
+
+}


### PR DESCRIPTION
Hi Team, this is the 2nd pull request from out of 2. In this branch I have made changes around:
1. Validation process of request and message: I have used Decrator pattern or Wrapper classes to have a single validator interface for the validation. Using this pattern, all validaors are extending from one  base class with each have their own validation business logic. Currently we only have 2 kind of validations, i.e. token and payload.. but in future we may have more. 
Hopefully I have not made things complex while trying to ease it up. If team agrees with this framework, i will update the test cases and remove old validators from codebase before merging this to parent branch. 
2. Added StackWalker API method: This will make sure method names are always correct and in terms of performance, this has very negligible effect. 

