### PR TITLE
Updated the error handling in hn-secure to provide more appropriate HTTP Status codes for specific errors

### DIFF
--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/messagevalidation/ExceptionHandler.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/messagevalidation/ExceptionHandler.java
@@ -51,11 +51,11 @@ public class ExceptionHandler implements Processor {
 			exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, SC_INTERNAL_SERVER_ERROR);
 			LOGGER.info("{} - Failed to connect remote server.",LoggingUtil.getMethodName());
 		} else {
-			// Should reach here as the exception should be handled above, add default error until the handling is added
+			// Should not reach here as the specific exception should be handled above, add default error in case the specific handling not added
 			exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, SC_INTERNAL_SERVER_ERROR);
 		}
 		
-		//Set the body to null as none is expected and this prevents hn-secure from attempting to create a FHIR JSON response body.
+		//Set the body to null as none is expected.
         exchange.getIn().setBody(null);
 	}
 }

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/messagevalidation/ExceptionHandler.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/messagevalidation/ExceptionHandler.java
@@ -1,31 +1,61 @@
 package ca.bc.gov.hlth.hnsecure.messagevalidation;
 
+import static ca.bc.gov.hlth.hnsecure.message.ErrorMessage.CustomError_Msg_InvalidAuthKey;
+import static ca.bc.gov.hlth.hnsecure.message.ErrorMessage.CustomError_Msg_InvalidRequest;
+import static ca.bc.gov.hlth.hnsecure.message.ErrorMessage.HL7Error_Msg_NoInputHL7;
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+import static org.apache.http.HttpStatus.SC_FORBIDDEN;
+import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
+import static org.apache.http.HttpStatus.SC_UNPROCESSABLE_ENTITY;
+
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
+import org.apache.http.conn.HttpHostConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import static ca.bc.gov.hlth.hnsecure.message.ErrorMessage.CustomError_Msg_InvalidRequest;;
+import ca.bc.gov.hlth.hncommon.util.LoggingUtil;
+import ca.bc.gov.hlth.hnsecure.exception.CustomHNSException;
+import ca.bc.gov.hlth.hnsecure.filedrops.FileDropGenerater;
 
 /**
- * Custom ExceptionHandler added to verify access token in request
- * @author pankaj.kathuria
+ * Custom ExceptionHandler to handle hn secure exceptions.
  *
  */
 public class ExceptionHandler implements Processor {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(FileDropGenerater.class);
 
     /**
-     * Validates the Hl7V2 transaction type (MSH.8) against the list of valid transaction type (valid-v2-message-types)
-     * @param v2Message the hl7v2 message to validate
-     */
-    
+     * Handle the exception thrown from the route. Based on the exception content it will add an
+     * appropriate HTTP Status Code.
+     * 
+     * @param exchange the exchange that is being processed
+     */    
 	@Override
-	public void process(Exchange exchange) throws Exception {
+	public void process(Exchange exchange) {
 
-        exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, 403);
-        exchange.getIn().setBody("{ \"error\": \""+CustomError_Msg_InvalidRequest+"\" }");
-        return;
-    
+		Exception exception = exchange.getProperty(Exchange.EXCEPTION_CAUGHT, Exception.class);
 		
+		if (exception instanceof CustomHNSException) {
+			if (CustomError_Msg_InvalidAuthKey.getErrorMessage().equals(exception.getMessage())) {
+				exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, SC_FORBIDDEN);
+			} else if (CustomError_Msg_InvalidRequest.getErrorMessage().equals(exception.getMessage())){
+				exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, SC_BAD_REQUEST);
+			} else if (HL7Error_Msg_NoInputHL7.getErrorMessage().equals(exception.getMessage())){
+				exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, SC_UNPROCESSABLE_ENTITY);
+			} else {
+				exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, SC_BAD_REQUEST);
+			}
+		} else if (exception instanceof HttpHostConnectException) {
+			exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, SC_INTERNAL_SERVER_ERROR);
+			LOGGER.info("{} - Failed to connect remote server.",LoggingUtil.getMethodName());
+		} else {
+			// Should reach here as the exception should be handled above, add default error until the handling is added
+			exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, SC_INTERNAL_SERVER_ERROR);
+		}
+		
+		//Set the body to null as none is expected and this prevents hn-secure from attempting to create a FHIR JSON response body.
+        exchange.getIn().setBody(null);
 	}
-
 }

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/FhirPayloadExtractor.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/FhirPayloadExtractor.java
@@ -1,5 +1,7 @@
 package ca.bc.gov.hlth.hnsecure.parsing;
 
+import static ca.bc.gov.hlth.hnsecure.message.ErrorMessage.CustomError_Msg_InvalidRequest;
+
 import java.io.UnsupportedEncodingException;
 
 import org.apache.camel.Exchange;
@@ -35,7 +37,7 @@ public class FhirPayloadExtractor {
         	extractedMessage = Util.decodeBase64(encodedExtractedMessage.getV2MessageData());
         }catch(IllegalArgumentException e) {
         	logger.error("Exception while decoding message ", e);
-        	throw new CustomHNSException(e.getMessage());
+        	throw new CustomHNSException(CustomError_Msg_InvalidRequest.getErrorMessage());
         }
         logger.debug("{} - TransactionId: {},{}", methodName, exchange.getIn().getMessageId(), "Message extracted successfully");
 		logger.debug("The decoded HL7 message is:"+extractedMessage);


### PR DESCRIPTION
- Updated the route to call ExceptionHandler for CustomHNSException and HttpHostConnectException
- Updated ExceptionHandler to set response header with HTTP Status codes specific to the error for CustomHNSExceptions and moved HttpHostConnectException handling there also
- Updated ExceptionHandler to set the body to null
- Updated route to only call encoder and wrapper when there is a 200 response as these will have a body
- Changed the logic to allow encoder and wrapper to be called when file drop is off 