### PR TITLE
Azure 3696 retrieve transaction id from http header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,10 @@
 */.idea/*
 *.project
 *.classpath
-*/.settings/*
 */bin/*
 */keystore/*
-hnsecure/logs/*
 logs/*
 */filedrops/*
+hnsecure/logs/*
+hnsecure/.settings/*
+

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/Route.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/Route.java
@@ -56,6 +56,8 @@ public class Route extends RouteBuilder {
 
 	private static final String BASIC = "Basic ";
 
+	private static final String HTTP_REQUEST_ID_HEADER = "X-Request-Id";
+
     // PharmaNet Endpoint values
 	@PropertyInject(value = "pharmanet.uri")
     private String pharmanetUri;
@@ -76,7 +78,15 @@ public class Route extends RouteBuilder {
     @SuppressWarnings("unchecked")
 	@Override
     public void configure() {
+
     	init();
+		setupSSLContextPharmanetRegistry(getContext());
+
+		String pharmaNetUrl = String.format(pharmanetUri + "?bridgeEndpoint=true&sslContextParameters=#%s&authMethod=Basic&authUsername=%s&authPassword=%s", SSL_CONTEXT_PHARMANET, pharmanetUser, pharmanetPassword);
+		log.info("Using pharmaNetUrl: " + pharmaNetUrl);
+
+		String basicToken = buildBasicToken(pharmanetUser, pharmanetPassword);
+		String isFileDropsEnabled = properties.getValue(IS_FILEDDROPS_ENABLED);
 
     	onException(CustomHNSException.class, HttpHostConnectException.class)
         	.process(new ExceptionHandler())
@@ -86,31 +96,31 @@ public class Route extends RouteBuilder {
                 .log("Validation exception response: ${body}")
                 .handled(true)
                 .id("ValidationException");
-        
-        setupSSLConextPharmanetRegistry(getContext());
-        String pharmNetUrl = String.format(pharmanetUri + "?bridgeEndpoint=true&sslContextParameters=#%s&authMethod=Basic&authUsername=%s&authPassword=%s", SSL_CONTEXT_PHARMANET, pharmanetUser, pharmanetPassword);
-        String basicToken = buildBasicToken(pharmanetUser, pharmanetPassword);
-        log.info("Using pharmNetUrl: " + pharmNetUrl);
-        
-        String isFileDropsEnabled = properties.getValue(IS_FILEDDROPS_ENABLED);
 
         from("jetty:http://{{hostname}}:{{port}}/{{endpoint}}").routeId("hnsecure-route")
 
-			//this route is only invoked when the original route is complete as a kind
+			// This route is only invoked when the original route is complete as a kind
 			// of completion callback.The onCompletion method is called once per route execution.
-			//Making it global will generate two response file drops.
+			// Making it global will generate two response file drops.
 			.onCompletion().modeBeforeConsumer().onWhen(header(Exchange.HTTP_RESPONSE_CODE).startsWith(HTTP_STATUS_OK_CODES)).id("Completion")
-			//creating filedrops if enabled
+				// create filedrops if enabled
 		    	.choice().when(header("isFileDropsEnabled").isEqualToIgnoreCase(Boolean.TRUE))
 		    		.bean(ResponseFileDropGenerater.class).id("ResponseFileDropGenerater")
 				.end()
-		    		//encoding response before sending to consumer
-		    		.setBody().method(new Base64Encoder()).id("Base64Encoder")
-		    		.setBody().method(new ProcessV2ToJson()).id("ProcessV2ToJson")
+				//encoding response before sending to consumer
+				.setBody().method(new Base64Encoder()).id("Base64Encoder")
+				.setBody().method(new ProcessV2ToJson()).id("ProcessV2ToJson")
 			.end()
-			
-			// here the original route continues
+
         	.log("HNSecure received a request")
+			// If a transaction ID is provided in the HTTP request header, use it as the exchange id instead of the camel generated id
+			.choice()
+				.when(header(HTTP_REQUEST_ID_HEADER))
+					.process(exchange -> {
+						exchange.setExchangeId(exchange.getIn().getHeader(HTTP_REQUEST_ID_HEADER, String.class));
+					})
+			.end()
+
         	.setHeader("isFileDropsEnabled").simple(isFileDropsEnabled)
         	// Extract the message using custom extractor and log 
         	.setBody().method(new FhirPayloadExtractor()).log("Decoded V2: ${body}")
@@ -118,42 +128,42 @@ public class Route extends RouteBuilder {
 			.wireTap("direct:start").end()
         	// Validate the message
         	.process(validator).id("Validator")
-            //set the receiving app, message type into headers
+            // Set the receiving app, message type into headers
             .bean(PopulateReqHeader.class).id("PopulateReqHeader")
             .to("log:HttpLogger?level=DEBUG&showBody=true&showHeaders=true&multiline=true")
             .log("The message receiving application is <${in.header.receivingApp}> and the message type is <${in.header.messageType}>.")     
             
-            //dispatch the message based on the receiving application code and message type
+            // Dispatch the message based on the receiving application code and message type
             .choice()
-	            //sending message to pharmaNet
+	            // Sending message to PharmaNet
             	.when(header("receivingApp").isEqualTo(Util.RECEIVING_APP_PNP))
                 	.log("Message identified as PharmaNet message. Preparing message for PharmaNet.")
             		.to("log:HttpLogger?level=DEBUG&showBody=true&multiline=true")
             		.setBody(body().regexReplaceAll("\r\n","\r"))
                     .setBody().method(new Base64Encoder())
 		            .setBody().method(new ProcessV2ToPharmaNetJson()).id("ProcessV2ToPharmaNetJson")
-		            .log("Sending to Pharmanet")
+		            .log("Sending to Pharamanet")
 		            .removeHeader(Exchange.HTTP_URI) //clean this header as it has been set in the "from" section
-		            .setHeader(Exchange.CONTENT_TYPE, constant("application/json"))		            
+		            .setHeader(Exchange.CONTENT_TYPE, constant("application/json"))
 		            .setHeader(CAMEL_HTTP_METHOD, POST)
 		            .setHeader(AUTHORIZATION, simple(basicToken))
 		            .to("log:HttpLogger?level=DEBUG&showBody=true&showHeaders=true&multiline=true")
-		            .to(pharmNetUrl).id("ToPharmaNet")
+		            .to(pharmaNetUrl).id("ToPharmaNet")
 		            .log("Received response from Pharmanet")
 		            .to("log:HttpLogger?level=DEBUG&showBody=true&showHeaders=true&multiline=true")
 		            .process(new PharmaNetPayloadExtractor())
 		            
-	            //sending message to HIBC for ELIG
+	            // sending message to HIBC for ELIG
 	            .when(simple("${in.header.messageType} == {{hibc-r15-endpoint}} || ${in.header.messageType} == {{hibc-e45-endpoint}}"))
 	                .log("the HIBC endpoint(${in.header.messageType}) is reached and message will be dispatched to message queue(ELIG).")
                     .setBody(simple(SampleMessages.e45ResponseMessage))
 	            
-	            //sending message to HIBC for ENROL
+	            // sending message to HIBC for ENROL
 	            .when(simple("${in.header.messageType} == {{hibc-r50-endpoint}}"))
 	                .log("the HIBC endpoint (${in.header.messageType}) is reached and message will be dispatched to message queue(ENROL).")
                     .setBody(simple(SampleMessages.r50ResponseMessage))
 	            
-	            //others sending to JMB
+	            // others sending to JMB
 	            .otherwise()
                     .log("the JMB endpoint is reached and message will be dispatched to JMB!!")
                     .setBody(simple(SampleMessages.r03ResponseMessage))
@@ -174,7 +184,7 @@ public class Route extends RouteBuilder {
 		return basicToken;
 	}
 
-	private void setupSSLConextPharmanetRegistry(CamelContext camelContext) {
+	private void setupSSLContextPharmanetRegistry(CamelContext camelContext) {
 		KeyStoreParameters ksp = new KeyStoreParameters();
         ksp.setResource(pharmanetCert);
         ksp.setPassword(pharmanetCertPassword);

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/Route.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/Route.java
@@ -118,7 +118,7 @@ public class Route extends RouteBuilder {
 				.when(header(HTTP_REQUEST_ID_HEADER))
 					.process(exchange -> {
 						exchange.setExchangeId(exchange.getIn().getHeader(HTTP_REQUEST_ID_HEADER, String.class));
-					})
+					}).id("SetExchangeIdFromHeader")
 			.end()
 
         	.setHeader("isFileDropsEnabled").simple(isFileDropsEnabled)

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/filedrops/ResponseFileDropGenerater.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/filedrops/ResponseFileDropGenerater.java
@@ -25,12 +25,11 @@ public class ResponseFileDropGenerater extends FileDropGenerater {
 
 	@Handler
 	public void createFileDrops(Exchange exchange) {
-		String fileName = buildFileNameParameters(exchange,exchange.getIn().getMessageId());
+		String fileName = buildFileNameParameters(exchange,exchange.getExchangeId());
 		String responseFileName = fileName + RESPONSE_FILE;		
 		writeFiledrop(exchange.getIn().getBody().toString(), responseFileName);
 		logger.info("{} - TransactionId: {}, Successfully created file drops for response: {}",
-				LoggingUtil.getMethodName(), exchange.getIn().getMessageId(),
-				responseFileName);
+				LoggingUtil.getMethodName(), exchange.getExchangeId(), responseFileName);
 	}
 
 }

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/json/pharmanet/ProcessV2ToPharmaNetJson.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/json/pharmanet/ProcessV2ToPharmaNetJson.java
@@ -41,11 +41,10 @@ public class ProcessV2ToPharmaNetJson {
 		} else {
 			String message = exchangeBody.toString();							
 			String transactionUUID = exchange.getExchangeId();
-			String transactionId = exchange.getIn().getMessageId();
 			String pharmacyId = exchange.getIn().getHeader(Util.PHARMACY_ID,String.class);
 			String traceId = exchange.getIn().getHeader(Util.TRACING_ID,String.class);			
 			logger.info("{} - TransactionId: {}, PharmacyId: {}, TraceNumber: {}, transactionUUID: {} ",
-					methodName, transactionId, pharmacyId, traceId, transactionUUID);
+					methodName, transactionUUID, pharmacyId, traceId, transactionUUID);
 			return PharmaNetJsonUtil.createJsonObjectPharmanet(transactionUUID, message).toString();
 		}
 	}

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/FhirPayloadExtractor.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/FhirPayloadExtractor.java
@@ -19,7 +19,7 @@ import net.minidev.json.parser.ParseException;
 
 public class FhirPayloadExtractor {
 
-    private static Logger logger = LoggerFactory.getLogger(FhirPayloadExtractor.class);
+    private static final Logger logger = LoggerFactory.getLogger(FhirPayloadExtractor.class);
 
     @Handler
     public static String extractFhirPayload(Exchange exchange,String fhirMessage) throws ParseException, UnsupportedEncodingException, CustomHNSException {
@@ -39,7 +39,7 @@ public class FhirPayloadExtractor {
         	logger.error("Exception while decoding message ", e);
         	throw new CustomHNSException(CustomError_Msg_InvalidRequest.getErrorMessage());
         }
-        logger.debug("{} - TransactionId: {},{}", methodName, exchange.getIn().getMessageId(), "Message extracted successfully");
+        logger.debug("{} - TransactionId: {},{}", methodName, exchange.getExchangeId(), "Message extracted successfully");
 		logger.debug("The decoded HL7 message is:"+extractedMessage);
         
         return extractedMessage;

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/PopulateReqHeader.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/PopulateReqHeader.java
@@ -58,9 +58,8 @@ public class PopulateReqHeader {
 			hm.put(Util.TRACING_ID, traceID);
 		}
 
-		logger.info("{} - TransactionId: {}, The exchange id is : {}, The receiving application is : {},The transaction type is :{} ", 
-				methodName, exchange.getExchangeId(),
-				exchange.getIn().getMessageId(),  recApp , msgType);
+		logger.info("{} - Transaction Id : {}, Receiving application : {}, Transaction type : {}, Sending Facility : {} ",
+				methodName, exchange.getExchangeId(), recApp , msgType, sendingFacility);
 	}
 	
 	

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/PayLoadValidator.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/PayLoadValidator.java
@@ -55,7 +55,7 @@ public class PayLoadValidator extends AbstractValidator {
 		String accessToken = (String) exchange.getIn().getHeader(AUTHORIZATION); 
 		// Validate v2Message format
 		String v2Message = (String) exchange.getIn().getBody();
-		String transactionId = (String) exchange.getIn().getMessageId();
+		String transactionId = exchange.getExchangeId();
 		validateMessageFormat(exchange, v2Message, messageObj);
 		boolean isPharmanetMode = isPharmanet(v2Message,messageObj, transactionId);
 		validateSendingFacility(exchange, messageObj, accessToken, isPharmanetMode);
@@ -244,7 +244,7 @@ public class PayLoadValidator extends AbstractValidator {
 		messageObject.setReceivingApplication(Util.RECEIVING_APP_HNSECURE);
 		ErrorResponse errorResponse = new ErrorResponse();		
 		String v2Response = errorResponse.constructResponse(messageObject, errorMessage);
-		logger.info("{} - TransactionId: {}, FacilityId: {}, Error message is: {}",methodName, exchange.getIn().getMessageId(),messageObject.getSendingFacility(), errorMessage);
+		logger.info("{} - TransactionId: {}, FacilityId: {}, Error message is: {}",methodName, exchange.getExchangeId(),messageObject.getSendingFacility(), errorMessage);
 		exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, 200);
 		exchange.getIn().setBody(v2Response);
 		throw new ValidationFailedException(errorMessage.getErrorMessage());
@@ -261,7 +261,7 @@ public class PayLoadValidator extends AbstractValidator {
 		messageObject.setReceivingApplication(Util.RECEIVING_APP_HNSECURE);
 		PharmanetErrorResponse errorResponse = new PharmanetErrorResponse();
 		String v2Response = errorResponse.constructResponse(messageObject, errorMessage);
-		logger.info("{} - TransactionId: {}, FacilityId: {}, Error message is: {}",methodName, exchange.getIn().getMessageId(),messageObject.getSendingFacility(), errorMessage);
+		logger.info("{} - TransactionId: {}, FacilityId: {}, Error message is: {}",methodName, exchange.getExchangeId(),messageObject.getSendingFacility(), errorMessage);
 		exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, 200);
 		exchange.getIn().setBody(v2Response);
 		throw new ValidationFailedException(errorMessage.getErrorMessage());

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/TokenValidator.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/TokenValidator.java
@@ -73,17 +73,17 @@ public class TokenValidator extends AbstractValidator {
 		// If more validataion is required for exchange message, we should create a new bean
 		String authorizationKey = (String) exchange.getIn().getHeader(AUTHORIZATION);
 		if(StringUtils.isBlank(authorizationKey)) {
-			logger.info("{} - TransactionId: {}, No authorization key passed in request header.", methodName, exchange.getIn().getMessageId());
+			logger.info("{} - TransactionId: {}, No authorization key passed in request header.", methodName, exchange.getExchangeId());
 			throw new CustomHNSException(CustomError_Msg_InvalidAuthKey.getErrorMessage());
 		}
 		AccessToken accessToken = AccessToken.parse(authorizationKey);
-		logger.info("{} - TransactionId: {}, Access token: {}", methodName,exchange.getIn().getMessageId(),accessToken);
+		logger.info("{} - TransactionId: {}, Access token: {}", methodName,exchange.getExchangeId(),accessToken);
 
 		// Process the token
 		JWTClaimsSet claimsSet = jwtProcessor.process(accessToken.toString(), null);
 
 		// Print out the token claims set
-		logger.info("{} - TransactionId: {}, TOKEN PAYLOAD: {}", methodName, exchange.getIn().getMessageId(), claimsSet.toJSONObject());
+		logger.info("{} - TransactionId: {}, TOKEN PAYLOAD: {}", methodName, exchange.getExchangeId(), claimsSet.toJSONObject());
 	
 		logger.info("TokenValidator Validation completed");
 		// After token call the  other validations. Type of validation depends on wrapped class when initializing

--- a/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/filedrops/V2FileDropsTest.java
+++ b/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/filedrops/V2FileDropsTest.java
@@ -16,7 +16,7 @@ public class V2FileDropsTest extends TestPropertiesLoader{
 		// 11b7bbb2-4668-4ab3-9794-624147d5d9e8-R03-moh_hnclient_dev-20210519225836
 		exchange.getIn().setHeader("Authorization", SamplesToSend.AUTH_HEADER);
 		String sendingFacility = Util.getSendingFacility((String)exchange.getIn().getHeader("Authorization"));
-		String fileName = Util.buildFileName(sendingFacility,exchange.getIn().getMessageId(), "R03");
+		String fileName = Util.buildFileName(sendingFacility,exchange.getExchangeId(), "R03");
 		String[] sections = fileName.split("-");
 		
 		// First 5 positions are the UUID


### PR DESCRIPTION
If X-Request-Id http header is included in a request we now set it to the ExchangeId
The ExchangeId is used as the transaction identifier for logging, auditing, and filedrops. 