### PR TITLE
3373 Database setup for audit information in Openshift

### DIFF
--- a/hnsecure/database/audit_logging_schema.sql
+++ b/hnsecure/database/audit_logging_schema.sql
@@ -1,0 +1,126 @@
+
+-- Clear existing schema
+
+DROP TABLE IF EXISTS hnsecure.EVENT_MESSAGE;
+DROP TABLE IF EXISTS hnsecure.TRANSACTION_EVENT;
+DROP TABLE IF EXISTS hnsecure.TRANSACTION_INFO;
+DROP TABLE IF EXISTS hnsecure.AFFECTED_PARTY;
+DROP TABLE IF EXISTS hnsecure.TRANSACTION;
+DROP SCHEMA IF EXISTS hnsecure;
+
+-- Beging Creating schema
+
+CREATE SCHEMA hnsecure;
+
+
+--TRANSACTION
+
+CREATE TABLE hnsecure.TRANSACTION (
+	TRANSACTION_ID	UUID CONSTRAINT PK_TRANSACTION PRIMARY KEY,
+	TYPE	VARCHAR(255),
+	SERVER	VARCHAR(255),
+	SOURCE	VARCHAR(255),
+	ORGANIZATION	VARCHAR(255),
+	USER_ID	VARCHAR(255),
+	FACILITY_ID	VARCHAR(255),
+	START_TIME TIMESTAMP WITH TIME ZONE
+);
+
+COMMENT ON TABLE hnsecure.TRANSACTION IS 'The transaction table stores a complete list of transactions that area processed by the ESB. This stores top level information';
+COMMENT ON COLUMN hnsecure.TRANSACTION.TRANSACTION_ID IS 'unique identifier for the transaction. this is to be issued by the ESB, not the database.';
+COMMENT ON COLUMN hnsecure.TRANSACTION.TYPE IS 'type of transaction. Pulled from the message header. for example E45, R15';
+COMMENT ON COLUMN hnsecure.TRANSACTION.SERVER IS 'name of the server that processed the transaction. (this may not be relevant in openshift)';
+COMMENT ON COLUMN hnsecure.TRANSACTION.SOURCE IS 'source system that sent the transaction. Use MSH.3 Sending Application';
+COMMENT ON COLUMN hnsecure.TRANSACTION.ORGANIZATION IS 'Organization that initiated the transaction';
+COMMENT ON COLUMN hnsecure.TRANSACTION.USER_ID IS 'ID of the user that initiated the transaction';
+COMMENT ON COLUMN hnsecure.TRANSACTION.FACILITY_ID IS 'use MSH.4 Sending Facility';
+COMMENT ON COLUMN hnsecure.TRANSACTION.START_TIME IS 'time that the transaction was started/created';
+
+--AFFECTED_PARTY
+
+CREATE TABLE hnsecure.AFFECTED_PARTY(
+	AFFECTED_PARTY_ID BIGSERIAL CONSTRAINT PK_AFFECTED_PARTY	primary KEY,
+	IDENTIFIER VARCHAR(255),
+	IDENTIFIER_SOURCE VARCHAR(255),
+	IDENTIFIER_TYPE VARCHAR(255),
+	STATUS VARCHAR(255),
+	TRANSACTION_ID	UUID,
+	CONSTRAINT FK_AFFECTED_PARTY_TRANSACTION
+      FOREIGN KEY(TRANSACTION_ID) 
+	  REFERENCES hnsecure.TRANSACTION(TRANSACTION_ID)
+);
+
+CREATE UNIQUE INDEX IXFX_AFFECTED_PARTY_TRANSACTION ON hnsecure.AFFECTED_PARTY (TRANSACTION_ID);
+
+COMMENT ON TABLE hnsecure.AFFECTED_PARTY IS 'Affected party stores data relevant to the parties that are the subject of the transaction. An example of an affected party would be a patient.';
+COMMENT ON COLUMN hnsecure.AFFECTED_PARTY.AFFECTED_PARTY_ID IS 'primary key';
+COMMENT ON COLUMN hnsecure.AFFECTED_PARTY.IDENTIFIER IS 'identifier number, such as a PHN or MRN';
+COMMENT ON COLUMN hnsecure.AFFECTED_PARTY.IDENTIFIER_SOURCE IS 'name of the source system that issued the identifier';
+COMMENT ON COLUMN hnsecure.AFFECTED_PARTY.IDENTIFIER_TYPE IS 'the type of identifier (PHN, MRN, drivers license no, etc)';
+COMMENT ON COLUMN hnsecure.AFFECTED_PARTY.STATUS IS 'Status of the identifier (Active, Merged, Deleted)';
+COMMENT ON COLUMN hnsecure.AFFECTED_PARTY.TRANSACTION_ID IS 'Foreign key to the transaction the party is the subject OF.';
+
+
+--TRANSACTION_INFO
+
+CREATE TABLE hnsecure.TRANSACTION_INFO(
+	TRANSACTION_ID	UUID,	
+	STATUS	VARCHAR(255),
+	TYPE	VARCHAR(255),
+	CONSTRAINT FK_TRANSACTION_INFO_TRANSACTION
+      FOREIGN KEY(TRANSACTION_ID) 
+	  REFERENCES hnsecure.TRANSACTION(TRANSACTION_ID)
+);
+
+CREATE UNIQUE INDEX IXFX_TRANSACTION_INFO_TRANSACTION ON hnsecure.TRANSACTION_INFO (TRANSACTION_ID);
+
+COMMENT ON TABLE hnsecure.TRANSACTION_INFO IS 'Transaction info is a table used to store status changes of a transaction.';
+COMMENT ON COLUMN hnsecure.TRANSACTION_INFO.TRANSACTION_ID IS 'foreign key to the transaction this event belongs TO.';
+COMMENT ON COLUMN hnsecure.TRANSACTION_INFO.STATUS IS 'Status of the transaction. For example transaction_complete';
+COMMENT ON COLUMN hnsecure.TRANSACTION_INFO.TYPE IS 'transation type';
+
+
+--TRANSACTION_EVENT
+
+CREATE TABLE hnsecure.TRANSACTION_EVENT(
+	TRANSACTION_EVENT_ID	BIGSERIAL CONSTRAINT PK_TRANSACTION_EVENT	PRIMARY KEY,
+	EVENT_TIME	TIMESTAMP WITH TIME ZONE,	
+	MESSAGE_ID	VARCHAR(255),
+	TYPE	VARCHAR(255),
+	TRANSACTION_ID	UUID,
+	CONSTRAINT FK_TRANSACTION_EVENT_TRANSACTION
+      FOREIGN KEY(TRANSACTION_ID) 
+	  REFERENCES hnsecure.TRANSACTION(TRANSACTION_ID)
+);
+
+CREATE UNIQUE INDEX IXFX_TRANSACTION_EVENT_TRANSACTION ON hnsecure.TRANSACTION_EVENT (TRANSACTION_ID);
+
+COMMENT ON TABLE hnsecure.TRANSACTION_EVENT IS 'The transaction event table is used to store information about events that occured during the course of a transaction.';
+COMMENT ON COLUMN hnsecure.TRANSACTION_EVENT.TRANSACTION_EVENT_ID IS 'primary key';
+COMMENT ON COLUMN hnsecure.TRANSACTION_EVENT.EVENT_TIME IS 'time that the event occured';
+COMMENT ON COLUMN hnsecure.TRANSACTION_EVENT.MESSAGE_ID IS 'message id created by the esb. could be an incoming, or the id generated for a response.';
+COMMENT ON COLUMN hnsecure.TRANSACTION_EVENT.TYPE IS 'transaction event type, for example error.';
+COMMENT ON COLUMN hnsecure.TRANSACTION_EVENT.TRANSACTION_ID IS 'foreign key to the transaction this event belongs TO.';
+
+
+--EVENT_MESSAGE
+
+CREATE TABLE hnsecure.EVENT_MESSAGE(
+	EVENT_MESSAGE_ID BIGSERIAL CONSTRAINT PK_EVENT_MESSAGE	PRIMARY KEY,
+	ERROR_CODE	VARCHAR(255),
+	ERROR_LEVEL	VARCHAR(255),
+	MESSAGE_TEXT	TEXT,
+	TRANSACTION_EVENT_ID	BIGINT,
+	CONSTRAINT FK_EVENT_MESSAGE_TRANSACTION_EVENT
+      FOREIGN KEY(TRANSACTION_EVENT_ID) 
+	  REFERENCES hnsecure.TRANSACTION_EVENT(TRANSACTION_EVENT_ID)
+);
+
+CREATE UNIQUE INDEX IXFX_EVENT_MESSAGE_TRANSACTION_EVENT ON hnsecure.EVENT_MESSAGE (TRANSACTION_EVENT_ID);
+
+COMMENT ON TABLE hnsecure.EVENT_MESSAGE IS 'The event message table stores data such as errors and warnings relevant to a transaction event that occurred. An event can have multiple messages.';
+COMMENT ON COLUMN hnsecure.EVENT_MESSAGE.EVENT_MESSAGE_ID IS 'primary key';
+COMMENT ON COLUMN hnsecure.EVENT_MESSAGE.ERROR_CODE IS 'Response or error code returned as a part of the event.';
+COMMENT ON COLUMN hnsecure.EVENT_MESSAGE.ERROR_LEVEL IS 'Error level, similar to logging levels (INFO, WARNING, ERROR, ETC)';
+COMMENT ON COLUMN hnsecure.EVENT_MESSAGE.MESSAGE_TEXT IS 'Complete response/error message text.';
+COMMENT ON COLUMN hnsecure.EVENT_MESSAGE.TRANSACTION_EVENT_ID IS 'foreign key to the original event';

--- a/hnsecure/pom.xml
+++ b/hnsecure/pom.xml
@@ -123,6 +123,25 @@
 	    <version>0.0.1-SNAPSHOT</version>
 	</dependency>    
 
+	<dependency>
+	    <groupId>org.apache.camel</groupId>
+	    <artifactId>camel-jdbc</artifactId>
+	</dependency>
+	
+	<!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->
+	<dependency>
+	    <groupId>org.postgresql</groupId>
+	    <artifactId>postgresql</artifactId>
+	    <version>42.2.22</version>
+	</dependency>        
+       	  
+	<!-- https://mvnrepository.com/artifact/commons-dbcp/commons-dbcp -->
+	<dependency>
+	    <groupId>commons-dbcp</groupId>
+	    <artifactId>commons-dbcp</artifactId>
+	    <version>1.4</version>
+	</dependency>
+	
   </dependencies>
 
   <build>

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/properties/ApplicationProperty.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/properties/ApplicationProperty.java
@@ -25,7 +25,9 @@ public enum ApplicationProperty {
 	HIBC_R15_ENDPOINT("hibc-r15-endpoint"),
 	HIBC_R50_ENDPOINT("hibc-r50-endpoint"),
 	IS_FILEDDROPS_ENABLED("is-filedrops-enabled"),
-	FILE_DROPS_LOCATION("file-drops-location");
+	FILE_DROPS_LOCATION("file-drops-location"),
+	AUDITS_ENABLED("audits.enabled");
+	
 	// Key should be same as the key in application.properties
 	private String key;
 	

--- a/hnsecure/src/main/resources/application.properties
+++ b/hnsecure/src/main/resources/application.properties
@@ -29,5 +29,6 @@ hibc-r50-endpoint="R50"
 
 # PharmaNet Endpoint
 pharmanet.uri=https://d1hni-connect.maximusbc.ca/pnetIntegration/submitTransaction
-
 pharmanet.cert=keystore/CGI-HNI-DEV.pfx
+
+audits.enabled=false

--- a/openshift/hni-deploy.yml
+++ b/openshift/hni-deploy.yml
@@ -27,6 +27,22 @@ spec:
                 secretKeyRef:
                     name: hnsesb-secret
                     key: PHARMANET_USER                    
+            - name: DATABASE_NAME
+              valueFrom:
+                secretKeyRef:
+                    name: postgre-db-service
+                    key: DATABASE_NAME                    
+            - name: DATABASE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                    name: postgre-db-service
+                    key: DATABASE_USERNAME                    
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                    name: postgre-db-service
+                    key: DATABASE_PASSWORD                    
+
         ports:
         - containerPort: 14885
           protocol: TCP

--- a/openshift/hni-network-policy-any-to-any.yml
+++ b/openshift/hni-network-policy-any-to-any.yml
@@ -1,0 +1,11 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace
+spec:
+  # Allow all pods within the current namespace to communicate
+  # to one another.
+  podSelector:
+  ingress:
+  - from:
+    - podSelector: {}

--- a/openshift/hni-postgresql-deployment-config.yml
+++ b/openshift/hni-postgresql-deployment-config.yml
@@ -1,0 +1,106 @@
+kind: DeploymentConfig
+apiVersion: apps.openshift.io/v1
+metadata:
+  name: hni-postgresql
+  namespace: c5839f-dev
+  labels:
+    app: hni-postgresql
+    app.kubernetes.io/component: hni-postgresql
+    app.kubernetes.io/instance: hni-postgresql
+    app.kubernetes.io/part-of: hnsesb
+spec:
+  strategy:
+    type: Recreate
+    recreateParams:
+      timeoutSeconds: 600
+    resources: {}
+    activeDeadlineSeconds: 21600
+  triggers:
+    - type: ImageChange
+      imageChangeParams:
+        automatic: true
+        containerNames:
+          - postgresql
+        from:
+          kind: ImageStreamTag
+          namespace: openshift
+          name: 'postgresql:10-el8'
+        lastTriggeredImage: >-
+          image-registry.openshift-image-registry.svc:5000/openshift/postgresql@sha256:276f2ee5b269cf2ba996900448a6112caf2e0a1517d0de424c1679d65009a0c6
+    - type: ConfigChange
+  replicas: 1
+  revisionHistoryLimit: 10
+  test: false
+  selector:
+    name: hni-postgresql
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        name: hni-postgresql
+      annotations:
+        openshift.io/generated-by: OpenShiftNewApp
+    spec:
+      volumes:
+        - name: hni-postgresql-data
+          persistentVolumeClaim:
+            claimName: hni-postgresql
+      containers:
+        - resources:
+            limits:
+              memory: 512Mi
+          readinessProbe:
+            exec:
+              command:
+                - /usr/libexec/check-container
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          terminationMessagePath: /dev/termination-log
+          name: postgresql
+          livenessProbe:
+            exec:
+              command:
+                - /usr/libexec/check-container
+                - '--live'
+            initialDelaySeconds: 120
+            timeoutSeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          env:
+            - name: POSTGRESQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: hni-postgresql
+                  key: database-user
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hni-postgresql
+                  key: database-password
+            - name: POSTGRESQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: hni-postgresql
+                  key: database-name
+          securityContext:
+            capabilities: {}
+            privileged: false
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: hni-postgresql-data
+              mountPath: /var/lib/pgsql/data
+          terminationMessagePolicy: File
+          image: >-
+            image-registry.openshift-image-registry.svc:5000/openshift/postgresql@sha256:276f2ee5b269cf2ba996900448a6112caf2e0a1517d0de424c1679d65009a0c6
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler

--- a/openshift/hni-postgresql-persistent-volume-claim.yml
+++ b/openshift/hni-postgresql-persistent-volume-claim.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hni-postgresql
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: netapp-file-standard
+  resources:
+    requests:
+      storage: 1Gi
+

--- a/openshift/hni-postgresql-service.yml
+++ b/openshift/hni-postgresql-service.yml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hni-postgresql
+  namespace: c5839f-dev
+  labels:
+    app: hni-postgresql
+spec:
+  ports:
+  - name: postgresql
+    protocol: TCP
+    port: 5432
+    targetPort: 5432
+  selector:
+    name: hni-postgresql


### PR DESCRIPTION
Configuration, setup and connectivity test on OpenShift for the Audit database including:
- Added yaml files for setup of a PostgreSql database.
- Added Audit database schema script.
- Added a jdbc component to the route for testing the database connection (this will be updated to use JPA).