### PR TITLE
Fixes for issues with messages generated on validation

### DIFF
--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/message/ErrorResponse.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/message/ErrorResponse.java
@@ -7,12 +7,7 @@ public class ErrorResponse extends ResponseSegment {
 	private static final String segmentIdentifier = "MSA";
 		
 	private static final String ackKnowledgementCode = "AR";
-	
-	private static final String ack = "ACK";
-	
 
-	
-	
 	@Override
 	public String constructResponse(HL7Message messageObj, ErrorMessage errorMessage) {
 		return constructMSH(messageObj) + constructMSA(messageObj.getMessageControlId(), errorMessage);
@@ -20,20 +15,15 @@ public class ErrorResponse extends ResponseSegment {
 	
 	public String constructMSA(String messageControlID, ErrorMessage errorMessage) {
 		StringBuilder sb = new StringBuilder(segmentIdentifier);
-		sb.append(getFieldseperator());
+		sb.append(FIELD_SEPARATOR);
 		sb.append(ackKnowledgementCode);
-		sb.append(getFieldseperator());
+		sb.append(FIELD_SEPARATOR);
 		sb.append(Optional.ofNullable(messageControlID).orElse(""));
-		sb.append(getFieldseperator());
-		sb.append(errorMessage.getErrorSequence()+ "  " + errorMessage.getErrorMessage());
-		sb.append(getFieldseperator());
+		sb.append(FIELD_SEPARATOR);
+		sb.append(errorMessage.getErrorSequence() + "  " + errorMessage.getErrorMessage());
+		sb.append(FIELD_SEPARATOR);
 
 		return sb.toString();
-		
 	}
 
-
-	public String getAck() {
-		return ack;
-	}
 }

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/message/ErrorResponse.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/message/ErrorResponse.java
@@ -2,6 +2,8 @@ package ca.bc.gov.hlth.hnsecure.message;
 
 import java.util.Optional;
 
+import ca.bc.gov.hlth.hnsecure.parsing.Util;
+
 public class ErrorResponse extends ResponseSegment {
 	
 	private static final String segmentIdentifier = "MSA";
@@ -15,13 +17,13 @@ public class ErrorResponse extends ResponseSegment {
 	
 	public String constructMSA(String messageControlID, ErrorMessage errorMessage) {
 		StringBuilder sb = new StringBuilder(segmentIdentifier);
-		sb.append(FIELD_SEPARATOR);
+		sb.append(Util.HL7_DELIMITER);
 		sb.append(ackKnowledgementCode);
-		sb.append(FIELD_SEPARATOR);
+		sb.append(Util.HL7_DELIMITER);
 		sb.append(Optional.ofNullable(messageControlID).orElse(""));
-		sb.append(FIELD_SEPARATOR);
+		sb.append(Util.HL7_DELIMITER);
 		sb.append(errorMessage.getErrorSequence() + "  " + errorMessage.getErrorMessage());
-		sb.append(FIELD_SEPARATOR);
+		sb.append(Util.HL7_DELIMITER);
 
 		return sb.toString();
 	}

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/message/HL7Message.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/message/HL7Message.java
@@ -4,27 +4,27 @@ public class HL7Message {
 
 	private String segmentIdentifier;
 	
-	private  String encodingCharacter;
+	private String encodingCharacter;
 
-	private  String sendingApplication;
+	private String sendingApplication;
 
-	private  String sendingFacility;
+	private String sendingFacility;
 
-	private  String receivingApplication;
+	private String receivingApplication;
 
-	private  String receivingFacility;
+	private String receivingFacility;
 
-	private  String dateTime;
+	private String dateTime;
 
-	private  String security;
+	private String security;
 
-	private  String messageType;
+	private String messageType;
 
-	private  String messageControlId;
+	private String messageControlId;
 
-	private  String processingId;
+	private String processingId;
 
-	private  String versionId;
+	private String versionId;
 
 	private final String fieldSeparator = "|";
 

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/message/PharmanetErrorResponse.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/message/PharmanetErrorResponse.java
@@ -36,13 +36,13 @@ public class PharmanetErrorResponse extends ResponseSegment {
 	 */
 	public String buildZCA() {
 		StringBuilder sb = new StringBuilder(ZCA_IDENTIFIER );
-		sb.append(FIELD_SEPARATOR);
-		sb.append(FIELD_SEPARATOR);
-		sb.append(FIELD_SEPARATOR);
+		sb.append(Util.HL7_DELIMITER);
+		sb.append(Util.HL7_DELIMITER);
+		sb.append(Util.HL7_DELIMITER);
 		sb.append(TRANSACTION_CODE);
-		sb.append(FIELD_SEPARATOR);
-		sb.append(FIELD_SEPARATOR);
-		sb.append(FIELD_SEPARATOR);
+		sb.append(Util.HL7_DELIMITER);
+		sb.append(Util.HL7_DELIMITER);
+		sb.append(Util.HL7_DELIMITER);
 		sb.append(Util.LINE_BREAK);
 		return sb.toString();
 	}
@@ -57,9 +57,9 @@ public class PharmanetErrorResponse extends ResponseSegment {
 
 	public String buildZCB() {
 		StringBuilder sb = new StringBuilder(ZCB_IDENTIFIER );
-		sb.append(FIELD_SEPARATOR);
-		sb.append(FIELD_SEPARATOR);
-		sb.append(FIELD_SEPARATOR);
+		sb.append(Util.HL7_DELIMITER);
+		sb.append(Util.HL7_DELIMITER);
+		sb.append(Util.HL7_DELIMITER);
 		sb.append(Util.LINE_BREAK);
 		return sb.toString();
 	}
@@ -70,17 +70,17 @@ public class PharmanetErrorResponse extends ResponseSegment {
 	 */
 	public String buildZZZ(ErrorMessage errorMessage) {
 		StringBuilder sb = new StringBuilder(ZZZ_IDENTIFIER );
-		sb.append(FIELD_SEPARATOR);
-		sb.append(FIELD_SEPARATOR);
+		sb.append(Util.HL7_DELIMITER);
+		sb.append(Util.HL7_DELIMITER);
 		sb.append(RESPONSE_STATUS);
-		sb.append(FIELD_SEPARATOR);
-		sb.append(FIELD_SEPARATOR);
-		sb.append(FIELD_SEPARATOR);
-		sb.append(FIELD_SEPARATOR);
-		sb.append(FIELD_SEPARATOR);
+		sb.append(Util.HL7_DELIMITER);
+		sb.append(Util.HL7_DELIMITER);
+		sb.append(Util.HL7_DELIMITER);
+		sb.append(Util.HL7_DELIMITER);
+		sb.append(Util.HL7_DELIMITER);
 		sb.append(errorMessage.getErrorSequence() + "  " + errorMessage.getErrorMessage());
-		sb.append(FIELD_SEPARATOR);
-		sb.append(FIELD_SEPARATOR);
+		sb.append(Util.HL7_DELIMITER);
+		sb.append(Util.HL7_DELIMITER);
 		return sb.toString();
 	}
 

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/message/PharmanetErrorResponse.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/message/PharmanetErrorResponse.java
@@ -36,13 +36,13 @@ public class PharmanetErrorResponse extends ResponseSegment {
 	 */
 	public String buildZCA() {
 		StringBuilder sb = new StringBuilder(ZCA_IDENTIFIER );
-		sb.append(getFieldseperator());
-		sb.append(getFieldseperator());
-		sb.append(getFieldseperator());
+		sb.append(FIELD_SEPARATOR);
+		sb.append(FIELD_SEPARATOR);
+		sb.append(FIELD_SEPARATOR);
 		sb.append(TRANSACTION_CODE);
-		sb.append(getFieldseperator());
-		sb.append(getFieldseperator());
-		sb.append(getFieldseperator());
+		sb.append(FIELD_SEPARATOR);
+		sb.append(FIELD_SEPARATOR);
+		sb.append(FIELD_SEPARATOR);
 		sb.append(Util.LINE_BREAK);
 		return sb.toString();
 	}
@@ -57,9 +57,9 @@ public class PharmanetErrorResponse extends ResponseSegment {
 
 	public String buildZCB() {
 		StringBuilder sb = new StringBuilder(ZCB_IDENTIFIER );
-		sb.append(getFieldseperator());
-		sb.append(getFieldseperator());
-		sb.append(getFieldseperator());
+		sb.append(FIELD_SEPARATOR);
+		sb.append(FIELD_SEPARATOR);
+		sb.append(FIELD_SEPARATOR);
 		sb.append(Util.LINE_BREAK);
 		return sb.toString();
 	}
@@ -70,17 +70,17 @@ public class PharmanetErrorResponse extends ResponseSegment {
 	 */
 	public String buildZZZ(ErrorMessage errorMessage) {
 		StringBuilder sb = new StringBuilder(ZZZ_IDENTIFIER );
-		sb.append(getFieldseperator());
-		sb.append(getFieldseperator());
+		sb.append(FIELD_SEPARATOR);
+		sb.append(FIELD_SEPARATOR);
 		sb.append(RESPONSE_STATUS);
-		sb.append(getFieldseperator());
-		sb.append(getFieldseperator());
-		sb.append(getFieldseperator());
-		sb.append(getFieldseperator());
-		sb.append(getFieldseperator());
-		sb.append(errorMessage.getErrorSequence()+ "  " + errorMessage.getErrorMessage());
-		sb.append(getFieldseperator());
-		sb.append(getFieldseperator());
+		sb.append(FIELD_SEPARATOR);
+		sb.append(FIELD_SEPARATOR);
+		sb.append(FIELD_SEPARATOR);
+		sb.append(FIELD_SEPARATOR);
+		sb.append(FIELD_SEPARATOR);
+		sb.append(errorMessage.getErrorSequence() + "  " + errorMessage.getErrorMessage());
+		sb.append(FIELD_SEPARATOR);
+		sb.append(FIELD_SEPARATOR);
 		return sb.toString();
 	}
 

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/message/ResponseSegment.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/message/ResponseSegment.java
@@ -3,17 +3,22 @@ package ca.bc.gov.hlth.hnsecure.message;
 import java.util.Optional;
 
 import ca.bc.gov.hlth.hnsecure.parsing.Util;
+import ca.bc.gov.hlth.hnsecure.properties.ApplicationProperties;
+import ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty;
 
 public abstract class ResponseSegment {
-	private static final String ack = "ACK";
 
-	private static final String fieldSeperator = "|";
+	protected static final String FIELD_SEPARATOR = "|";
 
-	private static final String encodingChar = "^~\\&";
+	private static final String ENCODING_CHARACTERS = "^~\\&";
 
-	private static final String unknownApp = "UNKNOWNAPP";
+	private static final String UNKNOWN_APP = "UNKNOWNAPP";
 
-	private static final String unknownClient = "UNKNOWNCLIENT";
+	private static final String UNKNOWN_CLIENT = "UNKNOWNCLIENT";
+	
+	private static final String PROCESSING_ID_UNKNOWN = "?";
+	
+	private static final ApplicationProperties properties = ApplicationProperties.getInstance();
 
 	abstract String constructResponse(HL7Message messageObj, ErrorMessage error);
 
@@ -44,7 +49,7 @@ public abstract class ResponseSegment {
 		sb.append(Optional.ofNullable(messageObj.getSegmentIdentifier()).orElse(""));
 		sb.append(messageObj.getFieldSeparator());
 
-		sb.append(encodingChar);
+		sb.append(ENCODING_CHARACTERS);
 		sb.append(messageObj.getFieldSeparator());
 
 		sb.append(Optional.ofNullable(messageObj.getReceivingApplication()).orElse(""));
@@ -53,47 +58,40 @@ public abstract class ResponseSegment {
 		sb.append(Optional.ofNullable(messageObj.getReceivingFacility()).orElse(""));
 		sb.append(messageObj.getFieldSeparator());
 
-		sb.append(Optional.ofNullable(messageObj.getSendingApplication()).orElse(unknownApp));
+		sb.append(Optional.ofNullable(messageObj.getSendingApplication()).orElse(UNKNOWN_APP));
 		sb.append(messageObj.getFieldSeparator());
 
-		sb.append(Optional.ofNullable(messageObj.getSendingFacility()).orElse(unknownClient));
+		sb.append(Optional.ofNullable(messageObj.getSendingFacility()).orElse(UNKNOWN_CLIENT));
 		sb.append(messageObj.getFieldSeparator());
 
-		if (messageObj.getMessageType() == null || !messageObj.getMessageType().equals(Util.MESSAGE_TYPE_PNP))
+		if (messageObj.getMessageType() == null || !messageObj.getMessageType().equals(Util.MESSAGE_TYPE_PNP)) {
 			sb.append(Util.getGenericDateTime());
-		else
+		} else {
 			sb.append(Util.getPharmanetDateTime());
+		}
 
 		sb.append(messageObj.getFieldSeparator());
 
 		sb.append(Optional.ofNullable(messageObj.getSecurity()).orElse(""));
 		sb.append(messageObj.getFieldSeparator());
 
-		sb.append(getAck());
-		sb.append(messageObj.getFieldSeparator());
-
-		sb.append(Optional.ofNullable(messageObj.getMessageType()).orElse(""));
+		// When constructing responses directly in HNS ESB (as opposed to something returned from a downstream system)
+		// the Message Type will always be ACK
+		sb.append(Util.ACK);
 		sb.append(messageObj.getFieldSeparator());
 
 		sb.append(Optional.ofNullable(messageObj.getMessageControlId()).orElse(""));
 		sb.append(messageObj.getFieldSeparator());
 
-		sb.append(Optional.ofNullable(messageObj.getProcessingId()).orElse(""));
+		sb.append(Optional.ofNullable(messageObj.getProcessingId()).orElse(PROCESSING_ID_UNKNOWN));
 		sb.append(messageObj.getFieldSeparator());
 
-		sb.append(Optional.ofNullable(messageObj.getVersionId()).orElse(""));
+		sb.append(Optional.ofNullable(messageObj.getVersionId()).orElse(properties.getValue(ApplicationProperty.VERSION)));
 
-		sb.append("\n");
+		sb.append(Util.LINE_BREAK);
 
 		return sb.toString();
 
 	}
 
-	public String getAck() {
-		return ack;
-	}
-
-	public static String getFieldseperator() {
-		return fieldSeperator;
-	}
 }

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/message/ResponseSegment.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/message/ResponseSegment.java
@@ -8,10 +8,6 @@ import ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty;
 
 public abstract class ResponseSegment {
 
-	protected static final String FIELD_SEPARATOR = "|";
-
-	private static final String ENCODING_CHARACTERS = "^~\\&";
-
 	private static final String UNKNOWN_APP = "UNKNOWNAPP";
 
 	private static final String UNKNOWN_CLIENT = "UNKNOWNCLIENT";
@@ -49,7 +45,7 @@ public abstract class ResponseSegment {
 		sb.append(Optional.ofNullable(messageObj.getSegmentIdentifier()).orElse(""));
 		sb.append(messageObj.getFieldSeparator());
 
-		sb.append(ENCODING_CHARACTERS);
+		sb.append(Util.ENCODING_CHARACTERS);
 		sb.append(messageObj.getFieldSeparator());
 
 		sb.append(Optional.ofNullable(messageObj.getReceivingApplication()).orElse(""));

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/Util.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/Util.java
@@ -31,7 +31,7 @@ public final class Util {
 	public final static String RECEIVING_APP_HNSECURE = "HNSECURE";
 	public final static String PHARMA_PATTERN = "yyyy/MM/dd HH:mm:ss";
 	public final static String DATE_PATTERN = "yyyyMMddHHmmss";
-	public final static String GENERIC_PATTERN = "yyyyMMddHHmmss Z";
+	public final static String GENERIC_PATTERN = "yyyyMMddHHmmssZ";
 	public final static String LINE_BREAK = "\n";
 	public static final String AUTHORIZATION = "Authorization";
 	public static final String ACK = "ACK";

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/Util.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/Util.java
@@ -37,6 +37,7 @@ public final class Util {
 	public static final String ACK = "ACK";
 	public static final String PHARMACY_ID = "pharmacyId";
 	public static final String TRACING_ID = "traceId";
+	public static final String ENCODING_CHARACTERS = "^~\\&";
 
 	/**
 	 * return a Base64 encoding string

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/PayLoadValidator.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/PayLoadValidator.java
@@ -82,7 +82,6 @@ public class PayLoadValidator extends AbstractValidator {
 			boolean isPharmanetMode) throws ValidationFailedException {
 		if (isPharmanetMode) {
 			if (!Util.isSegmentPresent(v2Message, Util.ZCB_SEGMENT)) {
-				populateFieldsForErrorResponse(messageObj);
 				generatePharmanetError(messageObj, ErrorMessage.HL7Error_Msg_TransactionFormatError, exchange);
 			}
 		}


### PR DESCRIPTION
The intention of this defect was to fix the issue of the message id not being populated when the request didn't contain one. After analysis of the legacy messages, it turns out the message id is just left blank. However, there were some additional discrepancies with legacy messages that were addressed:
- Fix the date formatting for non-Pharmanet messages
- Remove duplicate Message Type in response
- Add Version ID (read from properties)
- Add Processing ID (legacy defaults to ? when not provided/readable in request)

There was also some minor refactoring done to remove redundant code and follow best practices for naming.