### PR TITLE
Remove authorized party validation

### DIFF
--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/authorization/CustomJWTClaimsVerifier.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/authorization/CustomJWTClaimsVerifier.java
@@ -12,11 +12,7 @@ import java.util.Set;
 
 public class CustomJWTClaimsVerifier<C extends SecurityContext> extends DefaultJWTClaimsVerifier<C> {
 
-    /**
-     * The accepted authorized party values, {@code null} if not specified. A {@code null} value present in the set
-     * allows JWTs with no authorized parties.
-     */
-    private final Set<String> acceptedAuthorizedPartyValues;
+	private static final String CLAIM_SCOPE = "scope";
 
     /**
      * The accepted scope values, {@code null} if not specified. A {@code null} value present in the set allows JWTs
@@ -29,8 +25,6 @@ public class CustomJWTClaimsVerifier<C extends SecurityContext> extends DefaultJ
      *
      * @param acceptedAudience The accepted JWT audience values, {@code null} if not specified. A {@code null} value in
      * the set allows JWTs with no audience.
-     * @param acceptedAuthorizedParties The accepted JWT authorized party values, {@code null} if not specified. A
-     * {@code null} value in the set allows JWTs with no authorized parties.
      * @param acceptedScopes The accepted JWT scope values, {@code null} if not specified. A {@code null} value in the
      * set allows JWTs with no scopes.
      * @param exactMatchClaims The JWT claims that must match exactly, {@code null} if none.
@@ -39,16 +33,12 @@ public class CustomJWTClaimsVerifier<C extends SecurityContext> extends DefaultJ
      */
     public CustomJWTClaimsVerifier(
             final Set<String> acceptedAudience,
-            final Set<String> acceptedAuthorizedParties,
             final Set<String> acceptedScopes,
             final JWTClaimsSet exactMatchClaims,
             final Set<String> requiredClaims,
             final Set<String> prohibitedClaims) {
 
         super(acceptedAudience, exactMatchClaims, requiredClaims, prohibitedClaims);
-
-        this.acceptedAuthorizedPartyValues
-                = acceptedAuthorizedParties != null ? Collections.unmodifiableSet(acceptedAuthorizedParties) : null;
 
         this.acceptedScopeValues = acceptedScopes != null ? Collections.unmodifiableSet(acceptedScopes) : null;
     }
@@ -61,19 +51,7 @@ public class CustomJWTClaimsVerifier<C extends SecurityContext> extends DefaultJ
     @Override
     public void verify(final JWTClaimsSet claimsSet, final C context) throws BadJWTException {
         super.verify(claimsSet, context);
-        verifyAzpClaim(claimsSet);
         verifyScopeClaim(claimsSet);
-    }
-
-    /**
-     * Verify an azp claim against an accepted list of azp values
-     *
-     * @param claimsSet
-     */
-    private void verifyAzpClaim(final JWTClaimsSet claimsSet) throws BadJWTException {
-        String azp = "azp";
-        String azpValues = (String) claimsSet.getClaim(azp);
-        verifyClaim(azp, azpValues, acceptedAuthorizedPartyValues);
     }
 
     /**
@@ -82,9 +60,8 @@ public class CustomJWTClaimsVerifier<C extends SecurityContext> extends DefaultJ
      * @param claimsSet
      */
     private void verifyScopeClaim(final JWTClaimsSet claimsSet) throws BadJWTException {
-        String scope = "scope";
-        String scopeValues = (String) claimsSet.getClaim(scope);
-        verifyClaim(scope, scopeValues, acceptedScopeValues);
+        String scopeValues = (String) claimsSet.getClaim(CLAIM_SCOPE);
+        verifyClaim(CLAIM_SCOPE, scopeValues, acceptedScopeValues);
     }
 
     /**

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/properties/ApplicationProperty.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/properties/ApplicationProperty.java
@@ -12,7 +12,6 @@ public enum ApplicationProperty {
 	PORT("port"),
 	ENDPOINT("endpoint"),
 	AUDIENCE("audience"),
-	AUTHORIZED_PARTIES("authorized-parties"),
 	SCOPES("scopes"),
 	VALID_V2_MSG_TYPES("valid-v2-message-types"),
 	ISSUER("issuer"),

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/TokenValidator.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/validation/TokenValidator.java
@@ -3,7 +3,6 @@ package ca.bc.gov.hlth.hnsecure.validation;
 import static ca.bc.gov.hlth.hnsecure.message.ErrorMessage.CustomError_Msg_MissingAuthKey;
 import static ca.bc.gov.hlth.hnsecure.parsing.Util.AUTHORIZATION;
 import static ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty.AUDIENCE;
-import static ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty.AUTHORIZED_PARTIES;
 import static ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty.CERTS_ENDPOINT;
 import static ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty.ISSUER;
 import static ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty.SCOPES;
@@ -126,10 +125,8 @@ public class TokenValidator extends AbstractValidator {
 		// RSA keys sourced from the JWK set URL
 		JWSKeySelector<SecurityContext> keySelector = new JWSVerificationKeySelector<>(expectedJWSAlg, keySource);
 		jwtProcessor.setJWSKeySelector(keySelector);
-		
 
         Set<String> audiences =  Util.getPropertyAsSet(properties.getValue(AUDIENCE));
-    	Set<String> authorizedParties = Util.getPropertyAsSet(properties.getValue(AUTHORIZED_PARTIES));
     	Set <String> scopes = Util.getPropertyAsSet(properties.getValue(SCOPES));
 
 		// Set the required JWT claims - these must all be available in the token payload
@@ -137,8 +134,6 @@ public class TokenValidator extends AbstractValidator {
 				new CustomJWTClaimsVerifier<>(
 						// Accepted Audience -> aud
 						audiences,
-						// Accepted Authorized Parties -> azp
-						authorizedParties,
 						// Accepted Scopes -> scope
 						scopes,
 						// Exact Match Claims -> iss

--- a/hnsecure/src/main/resources/application.properties
+++ b/hnsecure/src/main/resources/application.properties
@@ -7,11 +7,8 @@ port = 14885
 endpoint = hl7v2
 
 # Access Token
-## audience, authorized-parties, and scopes can be comma delimited lists
+## audience and scopes can be comma delimited lists
 audience = account
-# For RTrans
-authorized-parties = BC01000121
-#authorized-parties = moh_hnclient_dev
 scopes = system/*.write
 valid-v2-message-types = r03, r07, r09, R50^Z05, r15, e45,ZPN
 issuer = https://common-logon-dev.hlth.gov.bc.ca/auth/realms/v2_pos

--- a/hnsecure/src/test/resources/application.properties
+++ b/hnsecure/src/test/resources/application.properties
@@ -7,11 +7,8 @@ port = 14880
 endpoint = hl7v2-test
 
 # Access Token
-## audience, authorized-parties, and scopes can be comma delimited lists
+## audience and scopes can be comma delimited lists
 audience = account
-# For RTrans
-#authorized-parties = BC01000121
-authorized-parties = moh_hnclient_dev
 scopes = system/*.write
 valid-v2-message-types = r03, r07, r09, R50^Z05, r15, e45,ZPN
 issuer = https://common-logon-dev.hlth.gov.bc.ca/auth/realms/v2_pos


### PR DESCRIPTION
It doesn't make sense to validate the claims on authorized party (azp) in the token because it would require keeping the list in HNS ESB in sync with every new client added through API gateway. Code was removed.