### PR TITLE
https://github.com/bcgov/moh-hni-esb/tree/3870-separate-test-logging.

### DIFF
--- a/hnsecure/src/test/resources/log4j2.properties
+++ b/hnsecure/src/test/resources/log4j2.properties
@@ -1,0 +1,30 @@
+# Console
+appender.out.type = Console
+appender.out.name = LogToConsole
+appender.out.layout.type = PatternLayout
+appender.out.layout.pattern = [%30.30t] %-30.30c{1} %-5p %m%n
+
+# Rotate log file
+appender.rolling.type = RollingFile
+appender.rolling.name = LogToRollingFile
+appender.rolling.fileName = logs/test.log
+appender.rolling.filePattern = logs/$${date:yyyy-MM}/app-%d{MM-dd-yyyy}-%i.log.gz
+appender.rolling.layout.type = PatternLayout
+appender.rolling.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS}[%10.10t] %-30.30c{1} %-5p %m%n
+appender.rolling.policies.type = Policies
+appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
+appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
+appender.rolling.policies.size.size=10MB
+appender.rolling.strategy.type = DefaultRolloverStrategy
+appender.rolling.strategy.max = 10
+
+# Log to console and rolling file
+logger.app.name = ca.bc.gov.hlth
+logger.app.level = DEBUG
+logger.app.additivity = false
+logger.app.appenderRef.rolling.ref = LogToRollingFile
+logger.app.appenderRef.console.ref = LogToConsole
+
+rootLogger.level = INFO
+rootLogger.appenderRef.fileLogger.ref = LogToRollingFile
+rootLogger.appenderRef.out.ref = LogToConsole


### PR DESCRIPTION
From https://dev.azure.com/cyrovalente/HNI%20Modernization/_workitems/edit/3870:

HSN ESB logs to two files: application.log (ca.bc.gov.hlth logging) and server.log (other logging). Unit tests shouldn't log to the same files as it can be confusing for debugging. It's also handy to have the unit tests log directly to the console for quick debugging in the IDE or Jenkins.

HNS Client only has a single log (hsnclient.log) but it would be good to separate test logging as well. We will use the same configuration for both.

The format of the main log4j2.properties could probably be cleaned up but it works fine as is so I just left it.