### PR TITLE
Removed Pharmacy Id and traceId from http request header

### DIFF
--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/Route.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/Route.java
@@ -193,7 +193,7 @@ public class Route extends RouteBuilder {
 		            .setHeader(AUTHORIZATION, simple(basicToken))
 		            .to("log:HttpLogger?level=DEBUG&showBody=true&showHeaders=true&multiline=true")
 		            .to(pharmaNetUrl).id("ToPharmaNet")
-		            .log("Received response from Pharmanet")
+		            .log("Received response from Pharmanet:${headers}")
 		            .to("log:HttpLogger?level=DEBUG&showBody=true&showHeaders=true&multiline=true")
 		            .process(new PharmaNetPayloadExtractor())
 		            .process(new AuditSetupProcessor(TransactionEventType.MESSAGE_RECEIVED))

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/json/pharmanet/ProcessV2ToPharmaNetJson.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/json/pharmanet/ProcessV2ToPharmaNetJson.java
@@ -41,8 +41,10 @@ public class ProcessV2ToPharmaNetJson {
 		} else {
 			String message = exchangeBody.toString();							
 			String transactionUUID = exchange.getExchangeId();
-			logger.info("{} - TransactionId: {}", methodName, transactionUUID);
-			
+			String pharmacyId = exchange.getIn().getHeader(Util.HEADER_PHARMACY_ID,String.class);
+			String traceId = exchange.getIn().getHeader(Util.HEADER_TRACING_ID,String.class);			
+			logger.info("{} - TransactionId: {}, PharmacyId: {}, TraceNumber: {}, transactionUUID: {} ",
+					methodName, transactionUUID, pharmacyId, traceId, transactionUUID);
 			return PharmaNetJsonUtil.createJsonObjectPharmanet(transactionUUID, message).toString();
 		}
 	}

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/json/pharmanet/ProcessV2ToPharmaNetJson.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/json/pharmanet/ProcessV2ToPharmaNetJson.java
@@ -40,11 +40,7 @@ public class ProcessV2ToPharmaNetJson {
 			throw new CustomHNSException(HL7Error_Msg_NoInputHL7);
 		} else {
 			String message = exchangeBody.toString();							
-			String transactionUUID = exchange.getExchangeId();
-			//String pharmacyId = exchange.getIn().getHeader(Util.HEADER_PHARMACY_ID,String.class);
-			//String traceId = exchange.getIn().getHeader(Util.HEADER_TRACING_ID,String.class);			
-			//logger.info("{} - TransactionId: {}, PharmacyId: {}, TraceNumber: {}, transactionUUID: {} ",
-					//methodName, transactionUUID, pharmacyId, traceId, transactionUUID);
+			String transactionUUID = exchange.getExchangeId();			
 			return PharmaNetJsonUtil.createJsonObjectPharmanet(transactionUUID, message).toString();
 		}
 	}

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/json/pharmanet/ProcessV2ToPharmaNetJson.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/json/pharmanet/ProcessV2ToPharmaNetJson.java
@@ -41,10 +41,10 @@ public class ProcessV2ToPharmaNetJson {
 		} else {
 			String message = exchangeBody.toString();							
 			String transactionUUID = exchange.getExchangeId();
-			String pharmacyId = exchange.getIn().getHeader(Util.HEADER_PHARMACY_ID,String.class);
-			String traceId = exchange.getIn().getHeader(Util.HEADER_TRACING_ID,String.class);			
-			logger.info("{} - TransactionId: {}, PharmacyId: {}, TraceNumber: {}, transactionUUID: {} ",
-					methodName, transactionUUID, pharmacyId, traceId, transactionUUID);
+			//String pharmacyId = exchange.getIn().getHeader(Util.HEADER_PHARMACY_ID,String.class);
+			//String traceId = exchange.getIn().getHeader(Util.HEADER_TRACING_ID,String.class);			
+			//logger.info("{} - TransactionId: {}, PharmacyId: {}, TraceNumber: {}, transactionUUID: {} ",
+					//methodName, transactionUUID, pharmacyId, traceId, transactionUUID);
 			return PharmaNetJsonUtil.createJsonObjectPharmanet(transactionUUID, message).toString();
 		}
 	}

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/json/pharmanet/ProcessV2ToPharmaNetJson.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/json/pharmanet/ProcessV2ToPharmaNetJson.java
@@ -40,7 +40,9 @@ public class ProcessV2ToPharmaNetJson {
 			throw new CustomHNSException(HL7Error_Msg_NoInputHL7);
 		} else {
 			String message = exchangeBody.toString();							
-			String transactionUUID = exchange.getExchangeId();			
+			String transactionUUID = exchange.getExchangeId();
+			logger.info("{} - transactionUUID: {}", methodName, transactionUUID);
+			
 			return PharmaNetJsonUtil.createJsonObjectPharmanet(transactionUUID, message).toString();
 		}
 	}

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/json/pharmanet/ProcessV2ToPharmaNetJson.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/json/pharmanet/ProcessV2ToPharmaNetJson.java
@@ -41,10 +41,8 @@ public class ProcessV2ToPharmaNetJson {
 		} else {
 			String message = exchangeBody.toString();							
 			String transactionUUID = exchange.getExchangeId();
-			String pharmacyId = exchange.getIn().getHeader(Util.HEADER_PHARMACY_ID,String.class);
-			String traceId = exchange.getIn().getHeader(Util.HEADER_TRACING_ID,String.class);			
-			logger.info("{} - TransactionId: {}, PharmacyId: {}, TraceNumber: {}, transactionUUID: {} ",
-					methodName, transactionUUID, pharmacyId, traceId, transactionUUID);
+			logger.info("{} - TransactionId: {}", methodName, transactionUUID);
+			
 			return PharmaNetJsonUtil.createJsonObjectPharmanet(transactionUUID, message).toString();
 		}
 	}

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/PopulateReqHeader.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/PopulateReqHeader.java
@@ -60,8 +60,8 @@ public class PopulateReqHeader {
 			String pharmacyID = V2MessageUtil.getPharmacyId(zcbSegment);
 			String traceID = V2MessageUtil.getTraceNumber(zcbSegment);
 			// These are actual http message headers that get send to Pharmanet
-			hm.put(Util.HEADER_PHARMACY_ID, pharmacyID);
-			hm.put(Util.HEADER_TRACING_ID, traceID);
+			//hm.put(Util.HEADER_PHARMACY_ID, pharmacyID);
+			//hm.put(Util.HEADER_TRACING_ID, traceID);
 		}
 
 		logger.info("{} - Transaction Id : {}, Receiving application : {}, Transaction type : {}, Sending Facility : {} ",

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/PopulateReqHeader.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/PopulateReqHeader.java
@@ -57,12 +57,11 @@ public class PopulateReqHeader {
 		
 		if (StringUtils.equals(Util.MESSAGE_TYPE_PNP, msgType)) {
 			String zcbSegment = V2MessageUtil.getZCBSegment(v2Message,Util.ZCB_SEGMENT);
-			String pharmacyId = V2MessageUtil.getPharmacyId(zcbSegment);
-			String traceId = V2MessageUtil.getTraceNumber(zcbSegment);
-			
-			//log PharmacyId and TraceId as per Pharmanet logging standards.		
-			logger.info("{} -  PharmacyId: {}, TraceId: {} ",
-					methodName, pharmacyId, traceId);
+			String pharmacyID = V2MessageUtil.getPharmacyId(zcbSegment);
+			String traceID = V2MessageUtil.getTraceNumber(zcbSegment);
+			// These are actual http message headers that get send to Pharmanet
+			hm.put(Util.HEADER_PHARMACY_ID, pharmacyID);
+			hm.put(Util.HEADER_TRACING_ID, traceID);
 		}
 
 		logger.info("{} - Transaction Id : {}, Receiving application : {}, Transaction type : {}, Sending Facility : {} ",

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/PopulateReqHeader.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/PopulateReqHeader.java
@@ -57,11 +57,12 @@ public class PopulateReqHeader {
 		
 		if (StringUtils.equals(Util.MESSAGE_TYPE_PNP, msgType)) {
 			String zcbSegment = V2MessageUtil.getZCBSegment(v2Message,Util.ZCB_SEGMENT);
-			String pharmacyID = V2MessageUtil.getPharmacyId(zcbSegment);
-			String traceID = V2MessageUtil.getTraceNumber(zcbSegment);
-			// These are actual http message headers that get send to Pharmanet
-			hm.put(Util.HEADER_PHARMACY_ID, pharmacyID);
-			hm.put(Util.HEADER_TRACING_ID, traceID);
+			String pharmacyId = V2MessageUtil.getPharmacyId(zcbSegment);
+			String traceId = V2MessageUtil.getTraceNumber(zcbSegment);
+			
+			//log PharmacyId and TraceId as per Pharmanet logging standards.		
+			logger.info("{} -  PharmacyId: {}, TraceId: {} ",
+					methodName, pharmacyId, traceId);
 		}
 
 		logger.info("{} - Transaction Id : {}, Receiving application : {}, Transaction type : {}, Sending Facility : {} ",

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/PopulateReqHeader.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/PopulateReqHeader.java
@@ -59,9 +59,8 @@ public class PopulateReqHeader {
 			String zcbSegment = V2MessageUtil.getZCBSegment(v2Message,Util.ZCB_SEGMENT);
 			String pharmacyID = V2MessageUtil.getPharmacyId(zcbSegment);
 			String traceID = V2MessageUtil.getTraceNumber(zcbSegment);
-			// These are actual http message headers that get send to Pharmanet
-			//hm.put(Util.HEADER_PHARMACY_ID, pharmacyID);
-			//hm.put(Util.HEADER_TRACING_ID, traceID);
+			logger.info("{} - Transaction Id : {}, Pharmacy Id : {}, TraceId : {}",
+					methodName, exchange.getExchangeId(), pharmacyID , traceID);
 		}
 
 		logger.info("{} - Transaction Id : {}, Receiving application : {}, Transaction type : {}, Sending Facility : {} ",

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/PopulateReqHeader.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/PopulateReqHeader.java
@@ -42,6 +42,7 @@ public class PopulateReqHeader {
 	public void populateReqHeader(Exchange exchange, @Headers Map<String, Object> hm, String v2Message)
 			throws Exception {
 		final String methodName = LoggingUtil.getMethodName();
+		String transactionUUID = exchange.getExchangeId();
 		
 		// The following values are properties used to control workflow
 		// and do not actually belong in the message header (which is converted to http request headers)
@@ -58,13 +59,13 @@ public class PopulateReqHeader {
 		if (StringUtils.equals(Util.MESSAGE_TYPE_PNP, msgType)) {
 			String zcbSegment = V2MessageUtil.getZCBSegment(v2Message,Util.ZCB_SEGMENT);
 			String pharmacyID = V2MessageUtil.getPharmacyId(zcbSegment);
-			String traceID = V2MessageUtil.getTraceNumber(zcbSegment);
+			String traceID = V2MessageUtil.getTraceNumber(zcbSegment);		
 			logger.info("{} - Transaction Id : {}, Pharmacy Id : {}, TraceId : {}",
-					methodName, exchange.getExchangeId(), pharmacyID , traceID);
+					methodName, transactionUUID, pharmacyID , traceID);
 		}
 
 		logger.info("{} - Transaction Id : {}, Receiving application : {}, Transaction type : {}, Sending Facility : {} ",
-				methodName, exchange.getExchangeId(), recApp , msgType, sendingFacility);
+				methodName, transactionUUID, recApp , msgType, sendingFacility);
 	}
 	
 	

--- a/hnsecure/src/main/resources/log4j2.properties
+++ b/hnsecure/src/main/resources/log4j2.properties
@@ -3,7 +3,7 @@
 #appender.out.name = out
 #appender.out.layout.type = PatternLayout
 #appender.out.layout.pattern = [%30.30t] %-30.30c{1} %-5p %m%n
-rootLogger.level = INFO
+rootLogger.level = DEBUG
 #rootLogger.appenderRef.out.ref = out
 #log4j.rootLogger= INFO, LogToFile, LogToRollingFile
 

--- a/hnsecure/src/main/resources/log4j2.properties
+++ b/hnsecure/src/main/resources/log4j2.properties
@@ -3,7 +3,7 @@
 #appender.out.name = out
 #appender.out.layout.type = PatternLayout
 #appender.out.layout.pattern = [%30.30t] %-30.30c{1} %-5p %m%n
-rootLogger.level = DEBUG
+rootLogger.level = INFO
 #rootLogger.appenderRef.out.ref = out
 #log4j.rootLogger= INFO, LogToFile, LogToRollingFile
 

--- a/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/parsing/PopulateReqHeaderTest.java
+++ b/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/parsing/PopulateReqHeaderTest.java
@@ -43,9 +43,7 @@ public class PopulateReqHeaderTest extends CamelTestSupport {
 		// Phamanet message only cares the receiving application value. If it is PNP,
 		// the message should be delivery to phamanet endpoint.
 		mock.expectedPropertyReceived(PROPERTY_MESSAGE_TYPE, "ZPN");
-		mock.expectedPropertyReceived(PROPERTY_RECEIVING_APP, "PNP");
-		mock.expectedHeaderReceived(Util.HEADER_PHARMACY_ID, "BCXX000024");
-		mock.expectedHeaderReceived(Util.HEADER_TRACING_ID, "18");
+		mock.expectedPropertyReceived(PROPERTY_RECEIVING_APP, "PNP");	
 		template.sendBody("direct:sampleHNSecure", MSG_PHARMANET);
 		assertMockEndpointsSatisfied();
 	}


### PR DESCRIPTION
The Pharmacy Id and Trace Id need not be set in request header as these are sensitive data and getting copied to response Header.