### PR TITLE
4235 run audit database script with database set up on open shift

### DIFF
--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/audit/entities/Transaction.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/audit/entities/Transaction.java
@@ -66,7 +66,7 @@ public class Transaction {
 	 * time that the transaction was started/created
 	 */
 	@Basic
-	@Column(name="start_time", columnDefinition="startTimetz")
+	@Column(name="start_time", columnDefinition="TIMESTAMPTZ")
 	private Date startTime;
 
 	public UUID getTransactionId() {

--- a/hnsecure/src/main/resources/META-INF/persistence.xml
+++ b/hnsecure/src/main/resources/META-INF/persistence.xml
@@ -12,8 +12,6 @@
 			<property name="javax.persistence.create-database-schemas" value="true"/>
 			<!-- Value of 'update' will allow the schema objects to be created if it does not exist but avoids "table x already exists" error when it does. -->			
 			<property name="hibernate.hbm2ddl.auto" value="update"/>
-			<property name ="hibernate.show_sql" value="true" />
-			<property name ="hibernate.format_sql" value="true" />
 		</properties>
 	</persistence-unit>
 </persistence>

--- a/hnsecure/src/main/resources/META-INF/persistence.xml
+++ b/hnsecure/src/main/resources/META-INF/persistence.xml
@@ -6,6 +6,8 @@
 		<properties>
 			<property name="javax.persistence.jdbc.driver" value="org.postgresql.Driver" />
 			<property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQL95Dialect"/>
+			<property name="javax.persistence.create-database-schemas" value="true"/>			
+			<property name="hibernate.hbm2ddl.auto" value="create-only"/>
 		</properties>
 	</persistence-unit>
 </persistence>

--- a/hnsecure/src/main/resources/META-INF/persistence.xml
+++ b/hnsecure/src/main/resources/META-INF/persistence.xml
@@ -6,8 +6,14 @@
 		<properties>
 			<property name="javax.persistence.jdbc.driver" value="org.postgresql.Driver" />
 			<property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQL95Dialect"/>
-			<property name="javax.persistence.create-database-schemas" value="true"/>			
-			<property name="hibernate.hbm2ddl.auto" value="create-only"/>
+			<!--  Causes the hibernate AvailableSettings field HBM2DLL_CREATE_SCHEMAS to be set. (See 
+			https://docs.jboss.org/hibernate/orm/5.1/javadocs/org/hibernate/cfg/AvailableSettings.html#HBM2DLL_CREATE_SCHEMAS). 
+			This is required because PostgresSql can have multiple databases and this indicates the database schema should be created. -->
+			<property name="javax.persistence.create-database-schemas" value="true"/>
+			<!-- Value of 'update' will allow the schema objects to be created if it does not exist but avoids "table x already exists" error when it does. -->			
+			<property name="hibernate.hbm2ddl.auto" value="update"/>
+			<property name ="hibernate.show_sql" value="true" />
+			<property name ="hibernate.format_sql" value="true" />
 		</properties>
 	</persistence-unit>
 </persistence>


### PR DESCRIPTION
Updated the persistence unit of the Audit database so that the database schema and schema objects get generated on application startup if they do not already exist. This means that they will get created on new deployments in OpenShift.

Also, fixed an error with the column type definition.