### PR TITLE
4385 intermittent timeout when sending messages to the jmb queues from hn secure

### DIFF
--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/message/ErrorMessage.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/message/ErrorMessage.java
@@ -26,7 +26,8 @@ public enum ErrorMessage {
 	CustomError_Msg_MissingAuthKey("HNSE001E", "No authorization key passed in request header."),
 	CustomError_Msg_InvalidAuthKey("HNSE002E", "Invalid token passed in request header."),
 	CustomError_Msg_DownstreamConnectionFailed("HNSE003E", "Downstream connection failed."),
-	CustomError_Msg_InvalidRequest("HNSE004E", "Invalid request.");
+	CustomError_Msg_InvalidRequest("HNSE004E", "Invalid request."),
+	CustomError_Msg_MQNotEnabled("HNSE005E", "MQ are not enabled");
 
 	private final String errorSequence;
 	private final String errorMessage;

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/messagevalidation/ExceptionHandler.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/messagevalidation/ExceptionHandler.java
@@ -8,7 +8,6 @@ import org.apache.camel.Exchange;
 import org.apache.camel.ExchangeTimedOutException;
 import org.apache.camel.Processor;
 import org.apache.http.conn.HttpHostConnectException;
-
 import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,6 +58,9 @@ public class ExceptionHandler implements Processor {
 			case CustomError_Msg_InvalidAuthKey:
 			case CustomError_Msg_MissingAuthKey:
 				handleException(exchange, errorMessage, HttpStatus.UNAUTHORIZED_401, TransactionEventType.UNAUTHENTICATED);
+				break;
+			case CustomError_Msg_MQNotEnabled:
+				handleException(exchange, errorMessage, HttpStatus.INTERNAL_SERVER_ERROR_500, TransactionEventType.ERROR);
 				break;
 			default:
 				handleException(exchange, ErrorMessage.HL7Error_Msg_Unknown, HttpStatus.BAD_REQUEST_400, TransactionEventType.ERROR);

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/Util.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/Util.java
@@ -43,6 +43,7 @@ public final class Util {
 
 	public static final String PROPERTY_IS_AUDITS_ENABLED = "isAuditsEnabled";
 	public static final String PROPERTY_IS_FILE_DROPS_ENABLED = "isFileDropsEnabled";
+	public static final String PROPERTY_IS_MQ_ENABLED = "isMQEnabled";
 	public static final String PROPERTY_MESSAGE_PROTOCOL = "messageProtocol";
 	public static final String PROPERTY_MESSAGE_TYPE = "messageType";
 	public static final String PROPERTY_RECEIVING_APP = "receivingApp";

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/properties/ApplicationProperty.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/properties/ApplicationProperty.java
@@ -20,7 +20,8 @@ public enum ApplicationProperty {
 	IS_FILEDDROPS_ENABLED("is.filedrops.enabled"),
 	FILE_DROPS_LOCATION("file.drops.location"),
 	IS_AUDITS_ENABLED("audits.enabled"),
-
+	IS_MQ_ENABLED("mq.enabled"),
+	
 	//Pharmanet properties
 	PHARMANET_URI("pharmanet.uri"),
 	PHARMANET_CERT_PASSWORD("pharmanet.cert.password"),

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/routes/BaseRoute.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/routes/BaseRoute.java
@@ -16,7 +16,7 @@ import ca.bc.gov.hlth.hnsecure.properties.ApplicationProperties;
 public abstract class BaseRoute extends RouteBuilder {
 	protected static final String JMS_DESTINATION_NAME_FORMAT = "queue:///%s?targetClient=1&&mdWriteEnabled=true";
 	
-	protected static final String MQ_URL_FORMAT = "jmsComponent:queue:%s?exchangePattern=InOut&replyTo=queue:///%s&replyToType=Exclusive&allowAdditionalHeaders=JMS_IBM_MQMD_MsgId";
+	protected static final String MQ_URL_FORMAT = "jmsComponent:queue:%s?exchangePattern=InOut&replyTo=queue:///%s&replyToType=Shared&allowAdditionalHeaders=JMS_IBM_MQMD_MsgId";
 	
 	protected static final ApplicationProperties properties = ApplicationProperties.getInstance(); 
 

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/routes/JMBRoute.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/routes/JMBRoute.java
@@ -1,10 +1,13 @@
 package ca.bc.gov.hlth.hnsecure.routes;
 
+import static ca.bc.gov.hlth.hnsecure.message.ErrorMessage.CustomError_Msg_MQNotEnabled;
+import static ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty.IS_MQ_ENABLED;
 import static ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty.JMB_REPLY_QUEUE;
 import static ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty.JMB_REQUEST_QUEUE;
 
 import ca.bc.gov.hlth.hnsecure.audit.AuditSetupProcessor;
 import ca.bc.gov.hlth.hnsecure.audit.entities.TransactionEventType;
+import ca.bc.gov.hlth.hnsecure.exception.CustomHNSException;
 import ca.bc.gov.hlth.hnsecure.parsing.PopulateJMSMessageHeader;
 
 public class JMBRoute extends BaseRoute {
@@ -12,24 +15,31 @@ public class JMBRoute extends BaseRoute {
 	@Override
 	public void configure() throws Exception {
 		
+		String isMQEnabled = properties.getValue(IS_MQ_ENABLED);
 		String jmbRequestQueue = properties.getValue(JMB_REQUEST_QUEUE);
 		String jmbReplyQueue = properties.getValue(JMB_REPLY_QUEUE);
 		String jmbUrl = String.format(MQ_URL_FORMAT, jmbRequestQueue, jmbReplyQueue);
 		
 		handleExceptions();
 
-		from("direct:jmb").routeId("jmb-route")
-	    	.log(String.format("Processing MQ Series. RequestQ : %s, ReplyQ: %s", jmbRequestQueue, jmbReplyQueue))
-	        .to("log:HttpLogger?level=DEBUG&showBody=true&showHeaders=true&multiline=true")
-	        .bean(new PopulateJMSMessageHeader()).id("PopulateJMSMessageHeader")
-			.log("jmb request message for R32 ::: ${body}")
-			.setHeader("CamelJmsDestinationName", constant(String.format(JMS_DESTINATION_NAME_FORMAT, jmbRequestQueue)))  
-	    	.process(new AuditSetupProcessor(TransactionEventType.MESSAGE_SENT))
-	    	.wireTap("direct:audit").end()
-			.to(jmbUrl).id("ToJmbUrl")
-	        .process(new AuditSetupProcessor(TransactionEventType.MESSAGE_RECEIVED))
-	        .wireTap("direct:audit").end()
-	        .log("Received response message for R32 ::: ${body}");
+		if (Boolean.valueOf(isMQEnabled)) {
+			from("direct:jmb").routeId("jmb-route")
+		    	.log(String.format("Processing MQ Series. RequestQ : %s, ReplyQ: %s", jmbRequestQueue, jmbReplyQueue))
+		        .to("log:HttpLogger?level=DEBUG&showBody=true&showHeaders=true&multiline=true")
+		        .bean(new PopulateJMSMessageHeader()).id("PopulateJMSMessageHeader")
+				.log("jmb request message for R32 ::: ${body}")
+				.setHeader("CamelJmsDestinationName", constant(String.format(JMS_DESTINATION_NAME_FORMAT, jmbRequestQueue)))  
+		    	.process(new AuditSetupProcessor(TransactionEventType.MESSAGE_SENT))
+		    	.wireTap("direct:audit").end()
+				.to(jmbUrl).id("ToJmbUrl")
+		        .process(new AuditSetupProcessor(TransactionEventType.MESSAGE_RECEIVED))
+		        .wireTap("direct:audit").end()
+		        .log("Received response message for R32 ::: ${body}");
+		} else {
+			from("direct:jmb").routeId("jmb-route")
+	    		.log("MQ routes are disabled.")
+		    	.throwException(new CustomHNSException(CustomError_Msg_MQNotEnabled));
+		} 
 	}
 	
 }

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/routes/Route.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/routes/Route.java
@@ -6,6 +6,7 @@ import static ca.bc.gov.hlth.hnsecure.parsing.V2MessageUtil.MessageType.R32;
 import static ca.bc.gov.hlth.hnsecure.parsing.V2MessageUtil.MessageType.R50;
 import static ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty.IS_AUDITS_ENABLED;
 import static ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty.IS_FILEDDROPS_ENABLED;
+import static ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty.IS_MQ_ENABLED;
 import static ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty.MQ_CHANNEL;
 import static ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty.MQ_HOST;
 import static ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty.MQ_PORT;
@@ -217,11 +218,17 @@ public class Route extends BaseRoute {
 	 */
 	private void initMQ() {
 		final String methodName = LoggingUtil.getMethodName();
-		JmsComponent jmsComponent = new JmsComponent();
-    	MQQueueConnectionFactory mqQueueConnectionFactory = mqQueueConnectionFactory();
-		jmsComponent.setConnectionFactory(mqQueueConnectionFactory);
-        getContext().addComponent("jmsComponent", jmsComponent);
-		logger.info("{} - Added JMS Component to context with connection factory. {}", methodName);			
+
+		boolean isMQEnabled = Boolean.valueOf(properties.getValue(IS_MQ_ENABLED));		
+		if (isMQEnabled) {
+			JmsComponent jmsComponent = new JmsComponent();
+	    	MQQueueConnectionFactory mqQueueConnectionFactory = mqQueueConnectionFactory();
+			jmsComponent.setConnectionFactory(mqQueueConnectionFactory);
+	        getContext().addComponent("jmsComponent", jmsComponent);
+			logger.info("{} - Added JMS Component to context with connection factory. {}", methodName);
+		} else {
+    		logger.info("{} - JMS Component has not been added as MQs are disabled. {}", methodName);
+    	}
 	}
     
     /**

--- a/hnsecure/src/main/resources/application.properties
+++ b/hnsecure/src/main/resources/application.properties
@@ -55,6 +55,7 @@ hibc.http.uri=http://hibc.hlth.gov.bc.ca
 #R50.protocol=MQ
 
 #MQ Properties
+mq.enabled=false
 mq.host=
 mq.channel=
 mq.port=


### PR DESCRIPTION
This change is to fix the issues around multiple apps connecting to the same MQ. Two changes:

- Changing replyToType property on the MQ url to 'Shared' to handle multiple connections
- Added a property to turn off/on MQ connection and route creation when starting the app. This is required because if the route containing the MQ url attempts to connect at route creation.