### PR TITLE
4622 Update properties for default file drops location; …

### DIFF
--- a/hnsecure/src/main/resources/application.properties
+++ b/hnsecure/src/main/resources/application.properties
@@ -9,8 +9,8 @@ endpoint = hl7v2
 valid.receiving.facility = BC00002041,BC00002047,BC00001013
 processing.domain = D
 version = 2.1
-is.filedrops.enabled =true
-file.drops.location = ./filedrops/
+is.filedrops.enabled=true
+file.drops.location=./logs/filedrops/
 audits.enabled=false
 
 # Keycloak endpoints

--- a/hnsecure/src/test/resources/application.properties
+++ b/hnsecure/src/test/resources/application.properties
@@ -15,8 +15,9 @@ valid.receiving.facility = BC00002041,BC00002047,BC00001013
 processing.domain = D
 version = 2.1
 is.filedrops.enabled = false
-file.drops.location = ./
+file.drops.location=./logs/filedrops/
 audits.enabled=false
+
 # Keycloak endpoints
 certs.endpoint = https://common-logon-dev.hlth.gov.bc.ca/auth/realms/v2_pos/protocol/openid-connect/certs
 
@@ -56,7 +57,7 @@ hibc.http.uri=http://hibc.hlth.gov.bc.ca
 #R50.protocol=MQ
 
 #MQ Properties
-mq.enabled=true
+mq.enabled=false
 mq.host=14.34.43.148
 mq.channel=CGICHANNEL
 mq.port=116


### PR DESCRIPTION
Defaulted filedrops location to the logs directory as this is persistent storage on OpenShift envs.
Default MQ to false as this should be turned off by default to avoid every dev instance connecting to the MQ.