### PR TITLE
5069 jenkins deploy bugfix

### DIFF
--- a/jenkins/jenkins.groovy
+++ b/jenkins/jenkins.groovy
@@ -1,4 +1,3 @@
-
 //-------------------------------------------------------------------
 // File: jenkins.groovy
 // Description: A util file for hnsesb jenkins jobs
@@ -16,6 +15,9 @@ def appName(val) {
 	return "hnsesb-" + val.toLowerCase()
 }
 
+// Method get build number and type to define tag
+// If build number is 121 and type is release then tag is RELEASE-BUILD-DEPLOY-121
+// For all other types, tag will be BUILD-DEPLOY-121
 def deployTag(DEPLOY_BUILD_NUMBER, DEPLOY_BUILD_TYPE){
 	def tag = "BUILD-DEPLOY-${DEPLOY_BUILD_NUMBER}"
 	if ("${DEPLOY_BUILD_TYPE}"=='Release'){

--- a/jenkins/jenkins.groovy
+++ b/jenkins/jenkins.groovy
@@ -1,0 +1,52 @@
+// This groovy script is used for jenkins jobs
+
+def project(NAMESPACE) {
+	def ns = "${NAMESPACE}"
+	return "c5839f-" + ns.toLowerCase()
+}
+
+def lower(val) {
+	def app = "${val}"
+	return val.toLowerCase()
+}
+
+def appName() {
+	def ns = "${NAMESPACE}"
+	return "hnsesb-" + ns.toLowerCase()
+}
+
+def deployTag(DEPLOY_BUILD_NUMBER, DEPLOY_BUILD_TYPE){
+	def tag = "BUILD-DEPLOY-${DEPLOY_BUILD_NUMBER}"
+	if ("${DEPLOY_BUILD_TYPE}"=='Release'){
+		tag = "RELEASE-BUILD-DEPLOY-${DEPLOY_BUILD_NUMBER}"
+	}
+	return tag
+}
+// Method to verfiy pods 
+def verifyPods(APP_NAME){
+    def pods =  openshift.selector( 'pods', [ app: '${APP_NAME}' ] )
+	// This will throw error, intended, if there are no pods with that application name
+	def podsObj = pods.objects()
+	// This loop will check if all pods are running status
+	pods.untilEach(1){
+	    echo "Checking pod status"
+	    def podObj = it.object()
+	    def podStatus = podObj.status.phase
+        if('Running'=="${podStatus}")								    {
+            // Got to next pod status check
+            return true;
+        }else{
+            sh 'False'
+        }
+	}
+}
+
+def example1() {
+  println 'Hello from example1'
+}
+
+def example2() {
+  println 'Hello from example2'
+}
+
+return this

--- a/jenkins/jenkins.groovy
+++ b/jenkins/jenkins.groovy
@@ -10,7 +10,7 @@ def project(val) {
 def lower(val) {
 	return val.toLowerCase()
 }
-// Prefix hnsesb- with passed value. This method is used for defining application name
+// Passed value is prefixed with hnesb-. This method is used for defining application name
 def appName(val) {
 	return "hnsesb-" + val.toLowerCase()
 }

--- a/jenkins/jenkins.groovy
+++ b/jenkins/jenkins.groovy
@@ -29,7 +29,6 @@ def verifyPods(val){
 	def pods =  openshift.selector( 'pods', [ app: val ] )
 	// This will throw error, intended, if there are no pods with that application name
 	def podsObj = pods.objects()
-	echo "Printing object ${podsObj}"
 	assert podsObj.size() > 0
 
 	// This loop will check if all pods are running status

--- a/jenkins/jenkins.groovy
+++ b/jenkins/jenkins.groovy
@@ -29,9 +29,9 @@ def verifyPods(val){
 	// This will throw error, intended, if there are no pods with that application name
 	def podsObj = pods.objects()
 	echo "Printing object ${podsObj}"
-	assert podsObj.count() > 0
+	assert podsObj.size() > 0
 	/*
-	if(podsObj.count()==0){
+	if(podsObj.size()==0){
 		echo "No pods found with that name."
 		sh 'False'
 	}

--- a/jenkins/jenkins.groovy
+++ b/jenkins/jenkins.groovy
@@ -29,6 +29,10 @@ def verifyPods(val){
 	// This will throw error, intended, if there are no pods with that application name
 	def podsObj = pods.objects()
 	echo "Printing object ${podsObj}"
+	if(podsObj.count()==0){
+		echo "No pods found with that name."
+		sh 'False'
+	}
 	// This loop will check if all pods are running status
 	timeout (time: 1, unit: 'MINUTES') {
 		pods.untilEach(1){

--- a/jenkins/jenkins.groovy
+++ b/jenkins/jenkins.groovy
@@ -49,12 +49,4 @@ def verifyPods(val){
 	}
 }
 
-def example1() {
-  println 'Hello from example1'
-}
-
-def example2() {
-  println 'Hello from example2'
-}
-
 return this

--- a/jenkins/jenkins.groovy
+++ b/jenkins/jenkins.groovy
@@ -30,12 +30,7 @@ def verifyPods(val){
 	def podsObj = pods.objects()
 	echo "Printing object ${podsObj}"
 	assert podsObj.size() > 0
-	/*
-	if(podsObj.size()==0){
-		echo "No pods found with that name."
-		sh 'False'
-	}
-	*/
+
 	// This loop will check if all pods are running status
 	timeout (time: 1, unit: 'MINUTES') {
 		pods.untilEach(1){

--- a/jenkins/jenkins.groovy
+++ b/jenkins/jenkins.groovy
@@ -3,15 +3,15 @@
 // File: jenkins.groovy
 // Description: A util file for hnsesb jenkins jobs
 //-------------------------------------------------------------------
-
+//This method returns namespace name with license plate prefix
 def project(val) {
 	return "c5839f-" + val.toLowerCase()
 }
-
+// Convert value to lowercase
 def lower(val) {
 	return val.toLowerCase()
 }
-
+// Prefix hnsesb- with passed value. This method is used for defining application name
 def appName(val) {
 	return "hnsesb-" + val.toLowerCase()
 }
@@ -24,6 +24,7 @@ def deployTag(DEPLOY_BUILD_NUMBER, DEPLOY_BUILD_TYPE){
 	return tag
 }
 // Method to verfiy pods 
+// Pass application name as argument to check if any pods exist for the application
 def verifyPods(val){
 	def pods =  openshift.selector( 'pods', [ app: val ] )
 	// This will throw error, intended, if there are no pods with that application name

--- a/jenkins/jenkins.groovy
+++ b/jenkins/jenkins.groovy
@@ -29,10 +29,13 @@ def verifyPods(val){
 	// This will throw error, intended, if there are no pods with that application name
 	def podsObj = pods.objects()
 	echo "Printing object ${podsObj}"
+	assert podsObj.count() > 0
+	/*
 	if(podsObj.count()==0){
 		echo "No pods found with that name."
 		sh 'False'
 	}
+	*/
 	// This loop will check if all pods are running status
 	timeout (time: 1, unit: 'MINUTES') {
 		pods.untilEach(1){

--- a/jenkins/jenkins.groovy
+++ b/jenkins/jenkins.groovy
@@ -1,18 +1,20 @@
-// This groovy script is used for jenkins jobs
 
-def project(NAMESPACE) {
-	def ns = "${NAMESPACE}"
-	return "c5839f-" + ns.toLowerCase()
+#!groovy
+//-------------------------------------------------------------------
+// File: jenkins.groovy
+// Description: A util file for hnsesb jenkins jobs
+//-------------------------------------------------------------------
+
+def project(val) {
+	return "c5839f-" + val.toLowerCase()
 }
 
 def lower(val) {
-	def app = "${val}"
 	return val.toLowerCase()
 }
 
-def appName() {
-	def ns = "${NAMESPACE}"
-	return "hnsesb-" + ns.toLowerCase()
+def appName(val) {
+	return "hnsesb-" + val.toLowerCase()
 }
 
 def deployTag(DEPLOY_BUILD_NUMBER, DEPLOY_BUILD_TYPE){
@@ -23,26 +25,20 @@ def deployTag(DEPLOY_BUILD_NUMBER, DEPLOY_BUILD_TYPE){
 	return tag
 }
 // Method to verfiy pods 
-def verifyPods(CLUSTER, OC_JENKINS_USER, PROJECT, APP_NAME){
-	openshift.withCluster( "${CLUSTER}" ) {
-        openshift.withCredentials( "${OC_JENKINS_USER}" ) {
-            openshift.withProject("${PROJECT}"){
-				def pods =  openshift.selector( 'pods', [ app: '${APP_NAME}' ] )
-				// This will throw error, intended, if there are no pods with that application name
-				def podsObj = pods.objects()
-				// This loop will check if all pods are running status
-				pods.untilEach(1){
-					echo "Checking pod status"
-					def podObj = it.object()
-					def podStatus = podObj.status.phase
-					if('Running'=="${podStatus}")								    {
-						// Got to next pod status check
-						return true;
-					}else{
-						sh 'False'
-					}
-				}
-			}
+def verifyPods(val){
+	def pods =  openshift.selector( 'pods', [ app: val ] )
+	// This will throw error, intended, if there are no pods with that application name
+	def podsObj = pods.objects()
+	// This loop will check if all pods are running status
+	pods.untilEach(1){
+		echo "Checking pod status"
+		def podObj = it.object()
+		def podStatus = podObj.status.phase
+		if('Running'==podStatus)								    {
+			// Got to next pod status check
+			return true;
+		}else{
+			sh 'False'
 		}
 	}
 }

--- a/jenkins/jenkins.groovy
+++ b/jenkins/jenkins.groovy
@@ -28,8 +28,10 @@ def verifyPods(val){
 	def pods =  openshift.selector( 'pods', [ app: val ] )
 	// This will throw error, intended, if there are no pods with that application name
 	def podsObj = pods.objects()
+	echo "Printing object ${podsObj}"
 	// This loop will check if all pods are running status
-	pods.untilEach(1){
+	timeout (time: 1, unit: 'MINUTES') {
+		pods.untilEach(1){
 		echo "Checking pod status"
 		def podObj = it.object()
 		def podStatus = podObj.status.phase
@@ -39,6 +41,7 @@ def verifyPods(val){
 		}else{
 			sh 'False'
 		}
+	}
 	}
 }
 

--- a/jenkins/jenkins.groovy
+++ b/jenkins/jenkins.groovy
@@ -23,21 +23,27 @@ def deployTag(DEPLOY_BUILD_NUMBER, DEPLOY_BUILD_TYPE){
 	return tag
 }
 // Method to verfiy pods 
-def verifyPods(APP_NAME){
-    def pods =  openshift.selector( 'pods', [ app: '${APP_NAME}' ] )
-	// This will throw error, intended, if there are no pods with that application name
-	def podsObj = pods.objects()
-	// This loop will check if all pods are running status
-	pods.untilEach(1){
-	    echo "Checking pod status"
-	    def podObj = it.object()
-	    def podStatus = podObj.status.phase
-        if('Running'=="${podStatus}")								    {
-            // Got to next pod status check
-            return true;
-        }else{
-            sh 'False'
-        }
+def verifyPods(CLUSTER, OC_JENKINS_USER, PROJECT, APP_NAME){
+	openshift.withCluster( "${CLUSTER}" ) {
+        openshift.withCredentials( "${OC_JENKINS_USER}" ) {
+            openshift.withProject("${PROJECT}"){
+				def pods =  openshift.selector( 'pods', [ app: '${APP_NAME}' ] )
+				// This will throw error, intended, if there are no pods with that application name
+				def podsObj = pods.objects()
+				// This loop will check if all pods are running status
+				pods.untilEach(1){
+					echo "Checking pod status"
+					def podObj = it.object()
+					def podStatus = podObj.status.phase
+					if('Running'=="${podStatus}")								    {
+						// Got to next pod status check
+						return true;
+					}else{
+						sh 'False'
+					}
+				}
+			}
+		}
 	}
 }
 

--- a/jenkins/jenkins.groovy
+++ b/jenkins/jenkins.groovy
@@ -1,5 +1,4 @@
 
-#!groovy
 //-------------------------------------------------------------------
 // File: jenkins.groovy
 // Description: A util file for hnsesb jenkins jobs

--- a/jenkins/jenkinspipeline-build-and-deploy-job.txt
+++ b/jenkins/jenkinspipeline-build-and-deploy-job.txt
@@ -40,7 +40,7 @@ pipeline {
                 }
             }
         }        
-		stage ("Load groovy util"){
+		stage ("Load groovy utility"){
             steps {
                 script {
 					util=load "jenkins/jenkins.groovy"

--- a/jenkins/jenkinspipeline-build-and-deploy-job.txt
+++ b/jenkins/jenkinspipeline-build-and-deploy-job.txt
@@ -19,11 +19,6 @@ pipeline {
                 // Get some code from a GitHub repository
                 echo "Getting code from main"
                 git branch: "${BRANCH_NAME}", url: "https://github.com/bcgov/moh-hni-esb"
-                util=load "jenkins/jenkins.groovy"
-                PROJECT = util.project("${NAMESPACE}")
-          		APP_NAME = util.lower("${Application}")
-				IMAGE_STREAM = "image-registry.openshift-image-registry.svc:5000/c5839f-tools/hnsesb:${APP_NAME}"
-		
             }
         }
  		stage("Package hn-common library") {
@@ -45,6 +40,16 @@ pipeline {
                 }
             }
         }        
+		stage ("Load groovy util"){
+            steps {
+                script {
+					util=load "jenkins/jenkins.groovy"
+					PROJECT = util.project("${NAMESPACE}")
+					APP_NAME = util.lower("${Application}")
+					IMAGE_STREAM = "image-registry.openshift-image-registry.svc:5000/c5839f-tools/hnsesb:${APP_NAME}"
+                }
+            }
+        }
         stage("Start Openshift build process") {
             steps {
 				script{

--- a/jenkins/jenkinspipeline-build-and-deploy-job.txt
+++ b/jenkins/jenkinspipeline-build-and-deploy-job.txt
@@ -110,11 +110,3 @@ pipeline {
         }
     }
 }
-def project() {
-	def ns = "${NAMESPACE}"
-	return "c5839f-" + ns.toLowerCase()
-}
-def appName() {
-	def ns = "${NAMESPACE}"
-	return "hnsesb-" + ns.toLowerCase()
-}

--- a/jenkins/jenkinspipeline-build-and-deploy-job.txt
+++ b/jenkins/jenkinspipeline-build-and-deploy-job.txt
@@ -9,9 +9,6 @@ pipeline {
 	environment {
 		CLUSTER = "openshift"
     	OC_JENKINS_USER = "deployer-c5839f-tools"
-		PROJECT = project()
-		APP_NAME = appName()
-		IMAGE_STREAM = "image-registry.openshift-image-registry.svc:5000/c5839f-tools/hnsesb:${APP_NAME}"
 		TAG = "${BRANCH_NAME}-${BUILD_NUMBER}"
 		TAG2 = "BUILD-DEPLOY-${BUILD_NUMBER}"
 	}
@@ -22,6 +19,11 @@ pipeline {
                 // Get some code from a GitHub repository
                 echo "Getting code from main"
                 git branch: "${BRANCH_NAME}", url: "https://github.com/bcgov/moh-hni-esb"
+                util=load "jenkins/jenkins.groovy"
+                PROJECT = util.project("${NAMESPACE}")
+          		APP_NAME = util.lower("${Application}")
+				IMAGE_STREAM = "image-registry.openshift-image-registry.svc:5000/c5839f-tools/hnsesb:${APP_NAME}"
+		
             }
         }
  		stage("Package hn-common library") {

--- a/jenkins/jenkinspipeline-build-and-deploy-job.txt
+++ b/jenkins/jenkinspipeline-build-and-deploy-job.txt
@@ -45,7 +45,7 @@ pipeline {
                 script {
 					util=load "jenkins/jenkins.groovy"
 					PROJECT = util.project("${NAMESPACE}")
-					APP_NAME = util.lower("${Application}")
+					APP_NAME = util.appName("${NAMESPACE}")
 					IMAGE_STREAM = "image-registry.openshift-image-registry.svc:5000/c5839f-tools/hnsesb:${APP_NAME}"
                 }
             }

--- a/jenkins/jenkinspipeline-deploy-job.txt
+++ b/jenkins/jenkinspipeline-deploy-job.txt
@@ -10,22 +10,27 @@ pipeline {
     environment {
     	// Input from user: NAMESPACE and DEPLOY_BUILD_NUMBER
     	CLUSTER = "openshift"
-    	BUILD_DEPLOY_TAG = deployTag()
-		OC_JEKNINS_USER = "deployer-c5839f-tools"
-		PROJECT = project()
+    	OC_JEKNINS_USER = "deployer-c5839f-tools"
 		TOOLS_PROJECT = "c5839f-tools"
-		APP_NAME = lower()
-
 		IMAGE_STREAM = "image-registry.openshift-image-registry.svc:5000/c5839f-tools/hnsesb"
-		IMAGE_STREAM_TAG = "imagestreamtag/hnsesb:${BUILD_DEPLOY_TAG}"
-		
-		APPLY_TAG=lower()
-		//eg : imagestreamtag/hnsesb:BUILD-DEPLOY-12 
 	}
 	
     agent any
 
     stages {
+		stage ("Load groovy utility"){
+			steps {
+				script {
+					util=load "jenkins/jenkins.groovy"
+					PROJECT = util.project("${NAMESPACE}")
+					APP_NAME = util.lower("${Application}")
+					BUILD_DEPLOY_TAG = util.deployTag("${DEPLOY_BUILD_NUMBER}","${DEPLOY_BUILD_TYPE}")
+					IMAGE_STREAM_TAG = "imagestreamtag/hnsesb:${BUILD_DEPLOY_TAG}"		
+					//eg : imagestreamtag/hnsesb:BUILD-DEPLOY-12 
+				}
+			}
+		}
+
         stage('Verify if application and build exists') {
             steps {
             	script {
@@ -44,15 +49,7 @@ pipeline {
                                 // Checking if application exists
                                 echo "Using project: ${openshift.project()} in cluster ${openshift.cluster()} "
                                 echo "Checking if application exists"
-								def podObj =  openshift.selector( 'pods', [ app: '${APP_NAME}' ] ).object()
-								def podStatus =  podObj.status.phase
-                                if ("${podStatus}"=='Running'){
-                                	echo 'Application exists'
-                                }
-                                else {
-                                	echo "${APP_NAME} Application does not exist. So exiting the job"
-                                	sh 'False'
-                                }
+								util.verifyPods("${Application}")
                             }
                         }
                     }            		
@@ -67,7 +64,7 @@ pipeline {
                     openshift.withCluster( "${CLUSTER}" ) {
                         openshift.withCredentials( "${OC_JEKNINS_USER}" ) {
                             openshift.withProject("${TOOLS_PROJECT}"){
-                                echo "Tag the build ${IMAGE_STREAM}:${BUILD_DEPLOY_TAG} with tag: ${APPLY_TAG} "
+                                echo "Tag the build ${IMAGE_STREAM}:${BUILD_DEPLOY_TAG} with tag: ${APP_NAME} "
                                 openshift.tag( "${IMAGE_STREAM}:${BUILD_DEPLOY_TAG}", "c5839f-tools/hnsesb:${APP_NAME}")
                             }
                         }
@@ -76,19 +73,4 @@ pipeline {
             }
         }
     }
-}
-def project() {
-	def ns = "${NAMESPACE}"
-	return "c5839f-" + ns.toLowerCase()
-}
-def lower() {
-	def app = "${Application}"
-	return app.toLowerCase()
-}
-def deployTag(){
-	def tag = "BUILD-DEPLOY-${DEPLOY_BUILD_NUMBER}"
-	if ("${DEPLOY_BUILD_TYPE}"=='Release'){
-		tag = "RELEASE-BUILD-DEPLOY-${DEPLOY_BUILD_NUMBER}"
-	}
-	return tag
 }

--- a/jenkins/jenkinspipeline-release-buildAndDeploy-job.txt
+++ b/jenkins/jenkinspipeline-release-buildAndDeploy-job.txt
@@ -105,6 +105,8 @@ pipeline {
 	        	script{
 	            	echo("Tagging the git commit: ${GIT_COMMIT}")
 	            	checkout([$class: 'GitSCM', branches: [[name: '*/main']], userRemoteConfigs: [[credentialsId: 'github-deploy-key', url: 'git@github.com:bcgov/moh-hni-esb.git']]])
+	            	sh('git config --local user.email "hnsesb-jenkins"')
+  					SH('git config --local user.name "hnsesb-jenkins"')
 	                sh ('git tag -a -f -m "Tagged by Jenkins Release process." "${TAG_GIT}" ')
 	                sh ('git push origin HEAD:$BRANCH_NAME --tags')
 					echo("Tagging complete")

--- a/jenkins/jenkinspipeline-set-up-hnsesb-job.txt
+++ b/jenkins/jenkinspipeline-set-up-hnsesb-job.txt
@@ -174,18 +174,8 @@ pipeline {
                         openshift.withCredentials( "${OC_JENKINS_USER}" ) {
                             openshift.withProject("${PROJECT}"){
                             	echo "Using project: ${openshift.project()} in cluster ${openshift.cluster()} "
-                          	    def dcSelector = openshift.selector( "dc", "${APP_NAME}")
-								dcSelector.logs('-f')
-								def dStatus = dcSelector.object().status.phase
-								def latestDeploymentVersion = openshift.selector('dc',"${APP_NAME}").object().status.latestVersion
-								def rc = openshift.selector('rc', "${APP_NAME}-${latestDeploymentVersion}")
-								timeout (time: 10, unit: 'MINUTES') {
-									rc.untilEach(1){
-										def rcMap = it.object()
-										return (rcMap.status.replicas.equals(rcMap.status.readyReplicas))
-									}
-								}
-								echo "Deployment status ${dStatus}"
+                          	    util.verifyPods("${APP_NAME}")
+								echo "Deployment status verified"
 							}
 						}
 					}

--- a/jenkins/jenkinspipeline-set-up-hnsesb-job.txt
+++ b/jenkins/jenkinspipeline-set-up-hnsesb-job.txt
@@ -27,12 +27,9 @@ pipeline {
 	environment {
 		CLUSTER = "openshift"
     	OC_JENKINS_USER = "deployer-c5839f-tools"
-    	APP_NAME = lower()
     	IMAGE = "hnsesb"
     	PROP_FILE_NAME = "application-external.properties"
-    	TAG = "${APP_NAME}"
-		PROJECT = project()
-		PHARMANET_CERT_SECRET = credentials("${PHARMANET_CERT_ID}")
+    	PHARMANET_CERT_SECRET = credentials("${PHARMANET_CERT_ID}")
 	}
     agent any
     stages {
@@ -61,7 +58,18 @@ pipeline {
                     }	
                 }
             }
-        }        
+        }   
+		stage ("Load groovy utility"){
+            steps {
+                script {
+					util=load "jenkins/jenkins.groovy"
+					PROJECT = util.project("${NAMESPACE}")
+					APP_NAME = util.lower("${Application}")
+					TAG = "${APP_NAME}"
+                }
+            }
+        }
+
         stage("Clean up existing application") {
             steps {
 				script{
@@ -191,13 +199,4 @@ pipeline {
             echo "Complete"
         }
     }
-}
-def project() {
-	def ns = "${NAMESPACE}"
-	return "c5839f-" + ns.toLowerCase()
-}
-
-def lower() {
-	def app = "${Application}"
-	return app.toLowerCase()
 }

--- a/jenkins/jenkinspipeline-set-up-hnsesb-job.txt
+++ b/jenkins/jenkinspipeline-set-up-hnsesb-job.txt
@@ -66,6 +66,7 @@ pipeline {
 					PROJECT = util.project("${NAMESPACE}")
 					APP_NAME = util.lower("${Application}")
 					TAG = "${APP_NAME}"
+					DB_POD_NAME = ""
                 }
             }
         }
@@ -174,7 +175,7 @@ pipeline {
                         openshift.withCredentials( "${OC_JENKINS_USER}" ) {
                             openshift.withProject("${PROJECT}"){
                             	echo "Using project: ${openshift.project()} in cluster ${openshift.cluster()} "
-                          	    //util.verifyPods("${APP_NAME}")
+                          	    util.verifyPods("${APP_NAME}")
 								echo "Deployment status verified"
 							}
 						}
@@ -188,7 +189,7 @@ pipeline {
         always {
             echo "Initial Set up Complete"
 			echo "Manual steps required:"
-			echo "Step 1. Connect with database pod: <Specify pod name>"
+			echo "Step 1. Connect with database pod using command --> oc port-forward <pod name> 15432:5432"
 			echo "Step 2. Run the database set up script."
         }
     }

--- a/jenkins/jenkinspipeline-set-up-hnsesb-job.txt
+++ b/jenkins/jenkinspipeline-set-up-hnsesb-job.txt
@@ -174,7 +174,7 @@ pipeline {
                         openshift.withCredentials( "${OC_JENKINS_USER}" ) {
                             openshift.withProject("${PROJECT}"){
                             	echo "Using project: ${openshift.project()} in cluster ${openshift.cluster()} "
-                          	    util.verifyPods("${APP_NAME}")
+                          	    //util.verifyPods("${APP_NAME}")
 								echo "Deployment status verified"
 							}
 						}
@@ -186,7 +186,10 @@ pipeline {
     }
     post {
         always {
-            echo "Complete"
+            echo "Initial Set up Complete"
+			echo "Manual steps required:"
+			echo "Step 1. Connect with database pod: <Specify pod name>"
+			echo "Step 2. Run the database set up script."
         }
     }
 }

--- a/jenkins/jenkinspipeline-set-up-hnsesb-job.txt
+++ b/jenkins/jenkinspipeline-set-up-hnsesb-job.txt
@@ -66,7 +66,6 @@ pipeline {
 					PROJECT = util.project("${NAMESPACE}")
 					APP_NAME = util.lower("${Application}")
 					TAG = "${APP_NAME}"
-					DB_POD_NAME = ""
                 }
             }
         }
@@ -188,9 +187,7 @@ pipeline {
     post {
         always {
             echo "Initial Set up Complete"
-			echo "Manual steps required:"
-			echo "Step 1. Connect with database pod using command --> oc port-forward <pod name> 15432:5432"
-			echo "Step 2. Run the database set up script."
+			echo "Additional set up required if Volume claims are required for this environment."
         }
     }
 }

--- a/jenkins/jenkinspipeline-set-up-hnsesb-job.txt
+++ b/jenkins/jenkinspipeline-set-up-hnsesb-job.txt
@@ -153,7 +153,7 @@ pipeline {
                             openshift.withProject("${PROJECT}"){
                             	echo "Using project: ${openshift.project()} in cluster ${openshift.cluster()} "
                           	    def bcSelector = openshift.selector( "buildconfig", "${APP_NAME}")
-								def buildRun = bcSelector.startBuild("--from-dir",".")
+								def buildRun = bcSelector.startBuild("--from-dir","./hnsecure")
 								buildRun.logs('-f')
 								def bStatus = buildRun.object().status.phase
 								echo "Status of build: ${bStatus}"

--- a/jenkins/jenkinspipeline-update-properties.txt
+++ b/jenkins/jenkinspipeline-update-properties.txt
@@ -55,7 +55,7 @@ pipeline {
                         openshift.withCredentials( "${OC_JENKINS_USER}" ) {
                             openshift.withProject("${PROJECT}"){
 								// Process will fail if it does not find object 	
-                            	openshift.selector('configMap/${CONFIG_MAP}').delete()
+                            	openshift.selector("configMap/${CONFIG_MAP}").delete()
 								echo "Config map ${CONFIG_MAP} deleted."
                             }
                         }

--- a/jenkins/jenkinspipeline-update-properties.txt
+++ b/jenkins/jenkinspipeline-update-properties.txt
@@ -24,7 +24,18 @@ pipeline {
 		PROP_FILE_NAME = "application-external.properties"
 	}
     agent any
+	
     stages {
+		stage ("Load groovy utility"){
+            steps {
+                script {
+					util=load "jenkins/jenkins.groovy"
+					PROJECT = util.project("${NAMESPACE}")
+					APP_NAME = util.lower("${Application}")
+					TAG = "${APP_NAME}"
+                }
+            }
+        }		
         stage('Verify if application exists') {
             steps {
             	script {
@@ -33,15 +44,7 @@ pipeline {
                             openshift.withProject("${PROJECT}"){
                                 echo "Using project: ${openshift.project()} in cluster ${openshift.cluster()} "
                                 echo "Checking if application exists"
-								def podObj =  openshift.selector( 'pods', [ app: '${APP_NAME}' ] ).object()
-								def podStatus =  podObj.status.phase
-                                if ("${podStatus}"=='Running'){
-                                	echo 'Application exists'
-                                }
-                                else {
-                                	echo "${APP_NAME} Application does not exist. So exiting the job"
-                                	sh 'False'
-                                }
+								util.verifyPods("${APP_NAME}")
                             }
                         }
                     }            		
@@ -98,13 +101,4 @@ pipeline {
             echo "Complete"
         }
     }
-}
-def project() {
-	def ns = "${NAMESPACE}"
-	return "c5839f-" + ns.toLowerCase()
-}
-
-def lower() {
-	def app = "${Application}"
-	return app.toLowerCase()
 }

--- a/jenkins/jenkinspipeline-update-properties.txt
+++ b/jenkins/jenkinspipeline-update-properties.txt
@@ -17,10 +17,6 @@ pipeline {
 	environment {
 		CLUSTER = "openshift"
     	OC_JENKINS_USER = "deployer-c5839f-tools"
-		PROJECT = project()
-		APP_NAME = lower()
-		// hard code to hnsesb-dev and later change to same as app name. 
-		CONFIG_MAP = lower()
 		PROP_FILE_NAME = "application-external.properties"
 	}
     agent any
@@ -32,6 +28,7 @@ pipeline {
 					util=load "jenkins/jenkins.groovy"
 					PROJECT = util.project("${NAMESPACE}")
 					APP_NAME = util.lower("${Application}")
+					CONFIG_MAP = "${APP_NAME}"
 					TAG = "${APP_NAME}"
                 }
             }


### PR DESCRIPTION
This branch is created to resolve a bug in Jenkins pipeline.
Issue 1: Jenkins deploy, update properties pipeline was failing for environments if hnsesb-application has multiple pods running.
Issue 2: Jenkins release build and deploy job was failing at tagging github repository stage. 

Cause 1: In the script, call to get resources using .object() was failing if there were more than 1 objects in response. It required .objects()
Cause 2: Missing git configurations of setting up identity before pushing the tags in git repository. 

Fix 1: Required to update the logic for verifying pods. Also did some refactoring to bring same code in single utility groovy file. And loading that utility in Jenkins pipeline.
Fix 2: Added command in the job to set local git configurations before pushing tags in repository.


Note: More refactoring of finding common code and bringing in single util file can be done in future.