### PR TITLE
Upgraded log4j2 to 2.16.0 to fix critical vulnerability

### DIFF
--- a/hnsecure/pom.xml
+++ b/hnsecure/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <log4j2-version>2.13.3</log4j2-version>
+    <log4j2-version>2.16.0</log4j2-version>
     <commons-lang3-version>3.12.0</commons-lang3-version>
     <oauth2-oidc-sdk-version>8.18</oauth2-oidc-sdk-version>
     <maven-compiler-plugin-version>3.8.1</maven-compiler-plugin-version>


### PR DESCRIPTION
See https://logging.apache.org/log4j/2.x/security.html.