### PR TITLE
fix bug for missing audit events

### DIFF
--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/audit/AuditProcessor.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/audit/AuditProcessor.java
@@ -40,7 +40,7 @@ public class AuditProcessor extends AbstractAuditPersistence implements Processo
 		String transactionId = (String) exchange.getProperty(Exchange.CORRELATION_ID);
 		Date eventTime = (Date) exchange.getProperty(Util.PROPERTY_TRANSACTION_EVENT_TIME);
 
-		String v2Message = (String) exchange.getIn().getBody();
+		String v2Message = exchange.getIn().getBody(String.class);
 		String msgType = V2MessageUtil.getMsgType(v2Message);
 		String messageId = null;
 		boolean logAffectedParties = false;

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/routes/HIBCRoute.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/routes/HIBCRoute.java
@@ -71,6 +71,7 @@ public class HIBCRoute extends BaseRoute {
 	     	.to("log:HttpLogger?level=DEBUG&showBody=true&showHeaders=true&multiline=true")
 	     	.to(hibcHttpUrl).id("ToHibcHttpUrl")
 			.to("log:HttpLogger?level=DEBUG&showBody=true&showHeaders=true&multiline=true")
+			.convertBodyTo(String.class)
 	     	.process(new AuditSetupProcessor(TransactionEventType.MESSAGE_RECEIVED))
 	     	.wireTap(DIRECT_AUDIT).end();
 


### PR DESCRIPTION
Update use of getBody method in AuditProcessor to avoid a class cast exception when body is an inputstream
Set the response body in HIBCRoute to be  a string so that it doesn't need to be re-assigned after it's retrieved in the audit processor (InputStream can only be read once)