### PR TITLE
Fixed issue with trying to audit missing ZCC segment.

### DIFF
--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/audit/persistence/AbstractAuditPersistence.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/audit/persistence/AbstractAuditPersistence.java
@@ -169,10 +169,13 @@ public abstract class AbstractAuditPersistence {
 				
 				switch (messageType) {
 				case ZPN:
-					//PharmaNet has client info in ZCC and ZPA
-					//ZCC e.g.
-					//ZCC||||||||||0009735000001|
-					String segment = V2MessageUtil.getSegment(segments, V2MessageUtil.SegmentType.ZCC); 
+					// ZCC e.g.
+					// ZCC||||||||||0009735000001|
+					String segment = V2MessageUtil.getSegment(segments, V2MessageUtil.SegmentType.ZCC);
+					// ZCC will not be populated in the event of an error
+					if (StringUtils.isBlank(segment)) {
+						break;
+					}
 					String[] segmentFields = V2MessageUtil.getSegmentFields(segment);
 					String patientIdentifier = V2MessageUtil.getIdentifierSectionZCC(segmentFields);	//ZCC Provincial Health Care ID field e.g. 0009735000001
 					affectedParty = new AffectedParty();		
@@ -180,8 +183,8 @@ public abstract class AbstractAuditPersistence {
 					affectedParties.add(affectedParty);		
 					break;
 				case E45:
-					//QPD e.g.
-					//QPD|E45^^HNET0003|1|^^00000001^^^CANBC^XX^MOH|^^00000001^^^CANBC^XX^MOH|^^00000754^^^CANBC^XX^MOH|9020198746^^^CANBC^JHN^MOH||19421112||||||19980601||PVC^^HNET9909
+					// QPD e.g.
+					// QPD|E45^^HNET0003|1|^^00000001^^^CANBC^XX^MOH|^^00000001^^^CANBC^XX^MOH|^^00000754^^^CANBC^XX^MOH|9020198746^^^CANBC^JHN^MOH||19421112||||||19980601||PVC^^HNET9909
 					List<String> segmentsQPD = V2MessageUtil.getSegments(segments, V2MessageUtil.SegmentType.QPD);
 					segmentsQPD.forEach(s -> {
 						String [] fields = V2MessageUtil.getSegmentFields(s);
@@ -197,9 +200,8 @@ public abstract class AbstractAuditPersistence {
 				case R15:
 				case R32:
 				case R50:
-					/* PID e.g. 
-					PID||0891250000^^^BC^PH 
-					*/
+					// PID e.g. 
+					// PID||0891250000^^^BC^PH 
 					List<String> segmentsPID = V2MessageUtil.getSegments(segments, V2MessageUtil.SegmentType.PID);
 					segmentsPID.forEach(s -> {
 						String [] fields = V2MessageUtil.getSegmentFields(s);

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/V2MessageUtil.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/V2MessageUtil.java
@@ -255,7 +255,7 @@ public class V2MessageUtil {
 	 */
 	public static boolean isSegmentPresent(String v2Message, String segmentType) {
 	
-		String[] v2DataLines = v2Message.split(Util.LINE_BREAK);
+		String[] v2DataLines = getMessageSegments(v2Message);
 	
 		for (String segment : v2DataLines) {
 	

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/V2MessageUtil.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/parsing/V2MessageUtil.java
@@ -230,7 +230,7 @@ public class V2MessageUtil {
 	 * @return
 	 */
 	public static String getDataSegment(String v2Message, String segmentType) {
-		String[] v2DataLinesPharmanet = v2Message.split(Util.LINE_BREAK);
+		String[] v2DataLinesPharmanet = getMessageSegments(v2Message);
 	
 		for (String segment : v2DataLinesPharmanet) {
 	

--- a/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/audit/persistence/AbstractAuditPersistenceTest.java
+++ b/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/audit/persistence/AbstractAuditPersistenceTest.java
@@ -3,6 +3,7 @@ package ca.bc.gov.hlth.hnsecure.audit.persistence;
 import static ca.bc.gov.hlth.hnsecure.parsing.Util.BCPHN;
 import static ca.bc.gov.hlth.hnsecure.test.TestMessages.MSG_PHARMANET_REQUEST;
 import static ca.bc.gov.hlth.hnsecure.test.TestMessages.MSG_PHARMANET_RESPONSE;
+import static ca.bc.gov.hlth.hnsecure.test.TestMessages.MSG_PHARMANET_ERROR_RESPONSE;
 import static ca.bc.gov.hlth.hnsecure.test.TestMessages.MSG_R03_REQUEST;
 import static ca.bc.gov.hlth.hnsecure.test.TestMessages.MSG_R03_RESPONSE;
 import static ca.bc.gov.hlth.hnsecure.test.TestMessages.MSG_R09_REQUEST;
@@ -183,6 +184,18 @@ public class AbstractAuditPersistenceTest extends TestPropertiesLoader {
 		assertEquals("123456789", affectedParty.getIdentifier()); //PHN in the ZCC
 		assertEquals(BCPHN, affectedParty.getIdentifierType());
 		assertEquals(AffectedPartyDirection.OUTBOUND.getValue(), affectedParty.getDirection());
+	}
+	
+	@Test
+	public void testCreateAffectedParties_MSG_PHARMANET_ERROR() {
+		UUID transactionId = UUID.randomUUID();
+		
+		AbstractAuditPersistence abstractAuditPersistence = Mockito.mock(
+				AbstractAuditPersistence.class, 
+			    Mockito.CALLS_REAL_METHODS);
+		// PNP error response sample has no ZCC segment and no affected parties should be written	 
+		List<AffectedParty> aps = abstractAuditPersistence.createAffectedParties(MSG_PHARMANET_ERROR_RESPONSE, AffectedPartyDirection.OUTBOUND, transactionId.toString());
+		assertTrue(aps.isEmpty());
 	}
 	
 	@Test

--- a/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/test/TestMessages.java
+++ b/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/test/TestMessages.java
@@ -19,6 +19,10 @@ public class TestMessages {
 			+ "ZZZ|TRP|0|1|P1|XXXXX||0 Operation successful\r\n"
 			+ "ZCC||||||||||123456789|\r\n" 
 			+ "ZPB|ZPB1^CLINICAL CONDITION DESCRIPTION^N^PA^19950101^CLINICAL";
+	
+	public static final String MSG_PHARMANET_ERROR_RESPONSE = "MSH|^~\\&|123456789|123456789|123456789|123456789|||ZPN|000001|P|2.1\r\n" 
+			+ "ZCB|PHARMACYXX|DATE|000001\r\n"  
+			+ "ZZZ||1|||||143 Request cannot be processed : Call Help Desk :Incident#12279159\r\n";
 
 	public static final String MSG_E45_REQUEST = "MSH|^~\\&|HR|BC00000098|RAIGET-DOC-SUM|BC0003000|19991004103039|lharris|E45|19980915000015|D|2.3"
 			+ "HDR|||TRAININGAdmin\r\n" + "SFT|1.0||testorg^^orgid^^^MOH|1.0|barebones||\r\n"


### PR DESCRIPTION
Fixed issue with not recognizing alternate line endings for PNET messages.