### PR TITLE
7855 implement rotation for filedrops

### DIFF
--- a/hnsecure/pom.xml
+++ b/hnsecure/pom.xml
@@ -88,10 +88,21 @@
       <artifactId>camel-direct</artifactId>
     </dependency>
     <dependency>
-    <groupId>org.apache.camel</groupId>
-    <artifactId>camel-netty</artifactId> 
-</dependency>
-
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-netty</artifactId> 
+	</dependency>
+	<dependency>
+	    <groupId>org.apache.camel</groupId>
+	    <artifactId>camel-quartz</artifactId>
+	</dependency>
+	
+	<!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
+	<dependency>
+	    <groupId>commons-io</groupId>
+	    <artifactId>commons-io</artifactId>
+	    <version>2.11.0</version>
+	</dependency>
+	
     <!-- oAuth2 token -->
     <dependency>
       <groupId>com.nimbusds</groupId>

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/HnsEsbMainMethod.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/HnsEsbMainMethod.java
@@ -7,6 +7,7 @@ import ca.bc.gov.hlth.hnsecure.routes.HandleResponseRoute;
 import ca.bc.gov.hlth.hnsecure.routes.JMBRoute;
 import ca.bc.gov.hlth.hnsecure.routes.PharmanetRoute;
 import ca.bc.gov.hlth.hnsecure.routes.RTransRoute;
+import ca.bc.gov.hlth.hnsecure.routes.RotateFilesRoute;
 import ca.bc.gov.hlth.hnsecure.routes.Route;
 import ca.bc.gov.hlth.hnsecure.routes.VersionRoute;
 
@@ -34,6 +35,7 @@ public final class HnsEsbMainMethod {
         main.configure().addRoutesBuilder(HIBCRoute.class);
         main.configure().addRoutesBuilder(JMBRoute.class);
         main.configure().addRoutesBuilder(HandleResponseRoute.class);
+        main.configure().addRoutesBuilder(RotateFilesRoute.class);
         main.run(args);
     }
     

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/filedrops/RotateFilesProcessor.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/filedrops/RotateFilesProcessor.java
@@ -5,6 +5,8 @@ import static ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty.FILE_DROPS_
 
 import java.io.File;
 import java.io.FileFilter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -55,13 +57,18 @@ public class RotateFilesProcessor extends AbstractAuditPersistence implements Pr
 		
         FileFilter ageFileFilter = new AgeFileFilter(cutoffDate, true);
         File[] filesToDelete = fileDropDirectory.listFiles(ageFileFilter);
+        logger.info("Found {} files delete.", filesToDelete.length);
         
         //Delete each file but and check for success 
         for (File f:filesToDelete) {
-        	boolean deleted = f.delete();
-        	if (!deleted) {
-				logger.warn("File {} could not be deleted.", f.getPath());
-        	}
+        	try {
+				boolean success = Files.deleteIfExists(Paths.get(f.getPath()));
+				if (success) {
+					logger.debug("Deleted file: {}", f.getName());
+				}
+			} catch (Exception e) {
+				logger.error("An error occurred attempting to delete file: {}; due to: {}.", f.getPath(), e.getMessage());
+			}
         }
         
         logger.info("Deletion of files has completed.");

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/filedrops/RotateFilesProcessor.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/filedrops/RotateFilesProcessor.java
@@ -1,0 +1,72 @@
+package ca.bc.gov.hlth.hnsecure.filedrops;
+
+import static ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty.FILE_DROPS_LOCATION;
+import static ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty.FILE_DROPS_ROTATION_DELETE_AFTER;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.AgeFileFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ca.bc.gov.hlth.hncommon.util.LoggingUtil;
+import ca.bc.gov.hlth.hnsecure.audit.persistence.AbstractAuditPersistence;
+import ca.bc.gov.hlth.hnsecure.properties.ApplicationProperties;
+
+/**
+ * Processor to handle file rotation policy. Currently this does a cleanup on logged request/response messages
+ *
+ */
+public class RotateFilesProcessor extends AbstractAuditPersistence implements Processor {
+
+	private static Logger logger = LoggerFactory.getLogger(RotateFilesProcessor.class);
+
+	private static final ApplicationProperties properties = ApplicationProperties.getInstance();
+	
+	@Override
+	public void process(Exchange exchange) {
+		String methodName = LoggingUtil.getMethodName();
+
+		logger.info("{} - Begin", methodName);
+		
+		//Delete logged request/response files older than specified number of days
+		
+		String fileDropLocation = properties.getValue(FILE_DROPS_LOCATION);
+		int deleteAfterDays = Integer.parseInt(properties.getValue(FILE_DROPS_ROTATION_DELETE_AFTER));
+		logger.info("Delete files from: {}; after: {} days.", fileDropLocation, deleteAfterDays);
+		
+		// Set a cut off date for file deletion to be the end of the day before the specified number of days to keep the files.
+        LocalDateTime cutoffLocalDateTime = LocalDate.now().minusDays(deleteAfterDays + 1).atTime(LocalTime.MAX);        
+        Date cutoffDate = Date.from(cutoffLocalDateTime.atZone(ZoneId.systemDefault()).toInstant());
+		logger.info("Delete files older than: {}.", cutoffDate);
+
+        File fileDropDirectory = new File(fileDropLocation);
+		long fileDropDirectorySizeBefore = FileUtils.sizeOfDirectory(fileDropDirectory);
+		logger.info("File drop directory size before cleanup: {}.", fileDropDirectorySizeBefore);
+		
+        FileFilter ageFileFilter = new AgeFileFilter(cutoffDate, true);
+        File[] filesToDelete = fileDropDirectory.listFiles(ageFileFilter);
+        
+        //Delete each file but and check for success 
+        for (File f:filesToDelete) {
+        	boolean deleted = f.delete();
+        	if (!deleted) {
+				logger.warn("File {} could not be deleted.", f.getPath());
+        	}
+        }
+        
+        logger.info("Deletion of files has completed.");
+		long fileDropDirectorySizeAfter = FileUtils.sizeOfDirectory(fileDropDirectory);
+		logger.info("File drop directory size after cleanup: {}. Freed {} bytes: ", fileDropDirectorySizeAfter, fileDropDirectorySizeBefore - fileDropDirectorySizeAfter);
+	}
+	
+}

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/properties/ApplicationProperty.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/properties/ApplicationProperty.java
@@ -19,6 +19,10 @@ public enum ApplicationProperty {
 	CERTS_ENDPOINT("certs.endpoint"),
 	IS_FILEDDROPS_ENABLED("is.filedrops.enabled"),
 	FILE_DROPS_LOCATION("file.drops.location"),
+	//File Drop rotation properties
+	FILE_DROPS_ROTATION_CRON("file.drops.rotation.cron"),
+	FILE_DROPS_ROTATION_DELETE_AFTER("file.drops.rotation.delete.after"),
+	
 	IS_AUDITS_ENABLED("audits.enabled"),
 	IS_MQ_ENABLED("mq.enabled"),
 	

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/routes/RotateFilesRoute.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/routes/RotateFilesRoute.java
@@ -27,7 +27,10 @@ public class RotateFilesRoute extends BaseRoute {
 
 		from(rotationSchedule).routeId("rotate-files-route")
 			.log("Processing file rotation")
-			.process(new RotateFilesProcessor());
+			.to("direct:processFileRotation").id("ToProcessFileRotation");
+		
+		from("direct:processFileRotation").id("ProcessFileRotation")
+		.process(new RotateFilesProcessor());
 	}
 
 }

--- a/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/routes/RotateFilesRoute.java
+++ b/hnsecure/src/main/java/ca/bc/gov/hlth/hnsecure/routes/RotateFilesRoute.java
@@ -1,0 +1,33 @@
+package ca.bc.gov.hlth.hnsecure.routes;
+
+import static ca.bc.gov.hlth.hnsecure.properties.ApplicationProperty.FILE_DROPS_ROTATION_CRON;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ca.bc.gov.hlth.hnsecure.filedrops.RotateFilesProcessor;
+import ca.bc.gov.hlth.hnsecure.properties.ApplicationProperties;
+
+/**
+ * Route to trigger processing of log files for cleanup. 
+ *
+ */
+public class RotateFilesRoute extends BaseRoute {
+
+	private static Logger logger = LoggerFactory.getLogger(RotateFilesProcessor.class);
+
+	private static final ApplicationProperties properties = ApplicationProperties.getInstance();
+
+	@Override
+	public void configure() throws Exception {
+
+		String cronSchedule = properties.getValue(FILE_DROPS_ROTATION_CRON);
+		logger.info("CRON Schedule: {}", cronSchedule);
+		final String rotationSchedule = String.format("quartz://rotateFiles?cron=%s", cronSchedule);
+
+		from(rotationSchedule).routeId("rotate-files-route")
+			.log("Processing file rotation")
+			.process(new RotateFilesProcessor());
+	}
+
+}

--- a/hnsecure/src/main/resources/application.properties
+++ b/hnsecure/src/main/resources/application.properties
@@ -11,6 +11,13 @@ processing.domain = D
 version = 2.1
 is.filedrops.enabled=true
 file.drops.location=./logs/filedrops/
+
+# file drop rotation
+# schedule for when the logged files cleanup route will be triggered e.g every day at midnight 0+0+0+*+*+?.
+file.drops.rotation.cron=
+# number of days after which the request/response messages will be deleted e.g. 90
+file.drops.rotation.delete.after=
+
 audits.enabled=false
 
 # Keycloak endpoints

--- a/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/route/RouteTest.java
+++ b/hnsecure/src/test/java/ca/bc/gov/hlth/hnsecure/route/RouteTest.java
@@ -20,6 +20,7 @@ import ca.bc.gov.hlth.hnsecure.routes.HandleResponseRoute;
 import ca.bc.gov.hlth.hnsecure.routes.JMBRoute;
 import ca.bc.gov.hlth.hnsecure.routes.PharmanetRoute;
 import ca.bc.gov.hlth.hnsecure.routes.RTransRoute;
+import ca.bc.gov.hlth.hnsecure.routes.RotateFilesRoute;
 import ca.bc.gov.hlth.hnsecure.routes.Route;
 import ca.bc.gov.hlth.hnsecure.samplemessages.SamplesToSend;
 
@@ -61,6 +62,7 @@ public class RouteTest extends CamelTestSupport {
 		context.addRoutes(new RTransRoute());
 		context.addRoutes(new HIBCRoute());
 		context.addRoutes(new JMBRoute());
+		context.addRoutes(new RotateFilesRoute());
 		context.addRoutes(new HandleResponseRoute());
 		
 		AdviceWithRouteBuilder.adviceWith(context, "hnsecure-route", a -> {
@@ -87,6 +89,9 @@ public class RouteTest extends CamelTestSupport {
 		});
 		AdviceWithRouteBuilder.adviceWith(context, "jmb-mq-route", a -> {
 			a.weaveById("ToJmbUrl").replace().to("mock:jmb");
+		});
+		AdviceWithRouteBuilder.adviceWith(context, "rotate-files-route", a -> {
+			a.weaveById("ToProcessFileRotation").replace().to("mock:rotateFiles");
 		});
 	}
 

--- a/hnsecure/src/test/resources/application.properties
+++ b/hnsecure/src/test/resources/application.properties
@@ -16,6 +16,12 @@ processing.domain = D
 version = 2.1
 is.filedrops.enabled = false
 file.drops.location=./logs/filedrops/
+
+# file drop rotation
+# schedule for every 5 seconds
+file.drops.rotation.cron=0+*+*+*+*+?
+file.drops.rotation.delete.after=90
+
 audits.enabled=false
 
 # Keycloak endpoints


### PR DESCRIPTION
Added file rotation for logged request/response files. This involves deleting these files once they are older than the specified number of days.