### PR TITLE
bcmoham-31376: update workflows to fix missing oc cli

### DIFF
--- a/.github/workflows/deploy-hnsesb.yml
+++ b/.github/workflows/deploy-hnsesb.yml
@@ -120,6 +120,11 @@ jobs:
           echo "TARGET_NAMESPACE=${{steps.get-namespace.outputs.result}}"  | tee -a $GITHUB_ENV
           echo "IMAGE_TAG=${{steps.get-image-prefix.outputs.result}}-${{github.event.inputs.Build_Run_Number}}"  | tee -a $GITHUB_ENV
 
+      - name: Install OpenShift CLI
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: latest
+
       # Login to OpenShift
       - name: Log in to OpenShift
         uses: redhat-actions/oc-login@v1
@@ -163,6 +168,11 @@ jobs:
           echo "TARGET_NAMESPACE=${{needs.validate.outputs.TARGET_NAMESPACE}}"  | tee -a $GITHUB_ENV
           echo "ENVIRONMENT=${{github.event.inputs.Environment}}"  | tee -a $GITHUB_ENV
           echo "BUILD_TYPE=${{github.event.inputs.Build_Type}}"  | tee -a $GITHUB_ENV
+
+      - name: Install OpenShift CLI
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: latest
 
       # Login to OpenShift
       - name: Log in to OpenShift
@@ -239,6 +249,11 @@ jobs:
           echo "TARGET_NAMESPACE=${{needs.validate.outputs.TARGET_NAMESPACE}}"  | tee -a $GITHUB_ENV
           echo "ENVIRONMENT=${{github.event.inputs.Environment}}"  | tee -a $GITHUB_ENV
           echo "BUILD_TYPE=${{github.event.inputs.Build_Type}}"  | tee -a $GITHUB_ENV
+
+      - name: Install OpenShift CLI
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: latest
 
       # Login to OpenShift
       - name: Log in to OpenShift

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -141,6 +141,11 @@ jobs:
           echo "IMAGE_TAG=${{steps.get-image-prefix.outputs.result}}-${{github.event.inputs.Build_Run_Number}}"  | tee -a $GITHUB_ENV
           echo "REPLICATE=${{steps.get-replication.outputs.result}}"  | tee -a $GITHUB_ENV
 
+      - name: Install OpenShift CLI
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: latest
+
       # Login to OpenShift
       - name: Log in to OpenShift
         uses: redhat-actions/oc-login@v1
@@ -171,7 +176,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate]
     steps:
-          # Login to Gold OpenShift
+      - name: Install OpenShift CLI
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: latest
+
+      # Login to Gold OpenShift
       - name: Log in to Gold OpenShift
         uses: redhat-actions/oc-login@v1
         with:

--- a/.github/workflows/feature-build-hniesb.yml
+++ b/.github/workflows/feature-build-hniesb.yml
@@ -106,6 +106,11 @@ jobs:
     needs: [createHniEsbFeatureBuild]
     
     steps:
+      - name: Install OpenShift CLI
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: latest
+
       # 1. Login to OpenShift
       - name: Log in to OpenShift
         uses: redhat-actions/oc-login@v1

--- a/.github/workflows/feature-build.yml
+++ b/.github/workflows/feature-build.yml
@@ -120,6 +120,11 @@ jobs:
     needs: [createHniEsbFeatureBuild]
     
     steps:
+      - name: Install OpenShift CLI
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: latest 
+
       # 1. Login to OpenShift
       - name: Log in to OpenShift
         uses: redhat-actions/oc-login@v1

--- a/.github/workflows/release-hnsesb.yml
+++ b/.github/workflows/release-hnsesb.yml
@@ -114,6 +114,11 @@ jobs:
         run: |
           echo "This step should move the image to repository to test namespace"
 
+      - name: Install OpenShift CLI
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: latest
+
       # 1. Login to OpenShift
       - name: Log in to OpenShift
         uses: redhat-actions/oc-login@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,10 @@ jobs:
     needs: [createHniEsbRelease]
     
     steps:
+      - name: Install OpenShift CLI
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: latest
 
       # 1. Login to OpenShift
       - name: Log in to OpenShift


### PR DESCRIPTION
Work Item: https://proactionca.ent.cgi.com/jira/browse/BCMOHAM-31376

Updates were made to the workflows to install the oc cli as it is no longer bundled with the runner used for the jobs. Updated workflows were:

- deploy
- deploy-hnsesb
- feature-build
- feature-build-hnsesb
- release
- release-hnsesb